### PR TITLE
Revert "fix(dns): prefer IPv6 addresses before IPv4 even if resolver ordered differently (#658)"

### DIFF
--- a/src/core/client/connect/dns.rs
+++ b/src/core/client/connect/dns.rs
@@ -264,7 +264,6 @@ mod sealed {
     use super::{Name, SocketAddr};
     use tower_service::Service;
 
-    // "Trait alias" for `Service<Name, Response = Addrs>`
     pub trait Resolve {
         type Addrs: Iterator<Item = SocketAddr>;
         type Error: Into<Box<dyn std::error::Error + Send + Sync>>;
@@ -300,4 +299,68 @@ where
 {
     future::poll_fn(|cx| resolver.poll_ready(cx)).await?;
     resolver.resolve(name).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
+    #[test]
+    fn test_ip_addrs_split_by_preference() {
+        let ip_v4 = Ipv4Addr::new(127, 0, 0, 1);
+        let ip_v6 = Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1);
+        let v4_addr = (ip_v4, 80).into();
+        let v6_addr = (ip_v6, 80).into();
+
+        let (mut preferred, mut fallback) = SocketAddrs {
+            iter: vec![v4_addr, v6_addr].into_iter(),
+        }
+        .split_by_preference(None, None);
+        assert!(preferred.next().unwrap().is_ipv4());
+        assert!(fallback.next().unwrap().is_ipv6());
+
+        let (mut preferred, mut fallback) = SocketAddrs {
+            iter: vec![v6_addr, v4_addr].into_iter(),
+        }
+        .split_by_preference(None, None);
+        assert!(preferred.next().unwrap().is_ipv6());
+        assert!(fallback.next().unwrap().is_ipv4());
+
+        let (mut preferred, mut fallback) = SocketAddrs {
+            iter: vec![v4_addr, v6_addr].into_iter(),
+        }
+        .split_by_preference(Some(ip_v4), Some(ip_v6));
+        assert!(preferred.next().unwrap().is_ipv4());
+        assert!(fallback.next().unwrap().is_ipv6());
+
+        let (mut preferred, mut fallback) = SocketAddrs {
+            iter: vec![v6_addr, v4_addr].into_iter(),
+        }
+        .split_by_preference(Some(ip_v4), Some(ip_v6));
+        assert!(preferred.next().unwrap().is_ipv6());
+        assert!(fallback.next().unwrap().is_ipv4());
+
+        let (mut preferred, fallback) = SocketAddrs {
+            iter: vec![v4_addr, v6_addr].into_iter(),
+        }
+        .split_by_preference(Some(ip_v4), None);
+        assert!(preferred.next().unwrap().is_ipv4());
+        assert!(fallback.is_empty());
+
+        let (mut preferred, fallback) = SocketAddrs {
+            iter: vec![v4_addr, v6_addr].into_iter(),
+        }
+        .split_by_preference(None, Some(ip_v6));
+        assert!(preferred.next().unwrap().is_ipv6());
+        assert!(fallback.is_empty());
+    }
+
+    #[test]
+    fn test_name_from_str() {
+        const DOMAIN: &str = "test.example.com";
+        let name = Name::from_str(DOMAIN).expect("Should be a valid domain");
+        assert_eq!(name.as_str(), DOMAIN);
+        assert_eq!(name.to_string(), DOMAIN);
+    }
 }

--- a/src/core/client/connect/dns.rs
+++ b/src/core/client/connect/dns.rs
@@ -220,13 +220,20 @@ impl SocketAddrs {
         local_addr_ipv4: Option<Ipv4Addr>,
         local_addr_ipv6: Option<Ipv6Addr>,
     ) -> (SocketAddrs, SocketAddrs) {
-        // Filter out based on what the local addr can use
         match (local_addr_ipv4, local_addr_ipv6) {
             (Some(_), None) => (self.filter(SocketAddr::is_ipv4), SocketAddrs::new(vec![])),
             (None, Some(_)) => (self.filter(SocketAddr::is_ipv6), SocketAddrs::new(vec![])),
             _ => {
-                // Happy Eyeballs says we always give a preference to v6 if available
-                let (preferred, fallback) = self.iter.partition::<Vec<_>, _>(SocketAddr::is_ipv6);
+                let preferring_v6 = self
+                    .iter
+                    .as_slice()
+                    .first()
+                    .map(SocketAddr::is_ipv6)
+                    .unwrap_or(false);
+
+                let (preferred, fallback) = self
+                    .iter
+                    .partition::<Vec<_>, _>(|addr| addr.is_ipv6() == preferring_v6);
 
                 (SocketAddrs::new(preferred), SocketAddrs::new(fallback))
             }
@@ -293,69 +300,4 @@ where
 {
     future::poll_fn(|cx| resolver.poll_ready(cx)).await?;
     resolver.resolve(name).await
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::net::{Ipv4Addr, Ipv6Addr};
-
-    #[test]
-    fn test_ip_addrs_split_by_preference() {
-        let ip_v4 = Ipv4Addr::new(127, 0, 0, 1);
-        let ip_v6 = Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1);
-        let v4_addr = (ip_v4, 80).into();
-        let v6_addr = (ip_v6, 80).into();
-
-        // Even if ipv4 started first, prefer ipv6
-        let (mut preferred, mut fallback) = SocketAddrs {
-            iter: vec![v4_addr, v6_addr].into_iter(),
-        }
-        .split_by_preference(None, None);
-        assert!(preferred.next().unwrap().is_ipv6());
-        assert!(fallback.next().unwrap().is_ipv4());
-
-        let (mut preferred, mut fallback) = SocketAddrs {
-            iter: vec![v6_addr, v4_addr].into_iter(),
-        }
-        .split_by_preference(None, None);
-        assert!(preferred.next().unwrap().is_ipv6());
-        assert!(fallback.next().unwrap().is_ipv4());
-
-        let (mut preferred, mut fallback) = SocketAddrs {
-            iter: vec![v4_addr, v6_addr].into_iter(),
-        }
-        .split_by_preference(Some(ip_v4), Some(ip_v6));
-        assert!(preferred.next().unwrap().is_ipv6());
-        assert!(fallback.next().unwrap().is_ipv4());
-
-        let (mut preferred, mut fallback) = SocketAddrs {
-            iter: vec![v6_addr, v4_addr].into_iter(),
-        }
-        .split_by_preference(Some(ip_v4), Some(ip_v6));
-        assert!(preferred.next().unwrap().is_ipv6());
-        assert!(fallback.next().unwrap().is_ipv4());
-
-        let (mut preferred, fallback) = SocketAddrs {
-            iter: vec![v4_addr, v6_addr].into_iter(),
-        }
-        .split_by_preference(Some(ip_v4), None);
-        assert!(preferred.next().unwrap().is_ipv4());
-        assert!(fallback.is_empty());
-
-        let (mut preferred, fallback) = SocketAddrs {
-            iter: vec![v4_addr, v6_addr].into_iter(),
-        }
-        .split_by_preference(None, Some(ip_v6));
-        assert!(preferred.next().unwrap().is_ipv6());
-        assert!(fallback.is_empty());
-    }
-
-    #[test]
-    fn test_name_from_str() {
-        const DOMAIN: &str = "test.example.com";
-        let name = Name::from_str(DOMAIN).expect("Should be a valid domain");
-        assert_eq!(name.as_str(), DOMAIN);
-        assert_eq!(name.to_string(), DOMAIN);
-    }
 }

--- a/src/core/client/connect/proxy/mod.rs
+++ b/src/core/client/connect/proxy/mod.rs
@@ -336,10 +336,9 @@ mod tests {
 
             // command req/res
             let n = to_client.read(&mut buf).await.expect("read 3");
-            let message = [0x05, 0x01, 0x00];
-            assert_eq!(&buf[..3], message);
-            assert!(buf[3] == 0x01 || buf[3] == 0x04); // IPv4 or IPv6
-            assert_eq!(n, 4 + 4 * (buf[3] as usize) + 2);
+            let message = [0x05, 0x01, 0x00, 0x01];
+            assert_eq!(&buf[..4], message);
+            assert_eq!(n, 4 + 4 + 2);
 
             let message = vec![0x05, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0];
             to_client.write_all(&message).await.expect("write 3");


### PR DESCRIPTION
This reverts commit e913768cf1be11b277b9b84b2f31b0090e426450.

from: https://github.com/hyperium/hyper/issues/3900