### PR TITLE
refactor(client): Move HTTP/2 safe retry logic into `tower` middleware

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ base64 = "0.22"
 url = "2.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_urlencoded = "0.7.1"
-tower = { version = "0.5.2", default-features = false, features = ["timeout","util"] }
+tower = { version = "0.5.2", default-features = false, features = ["timeout","util", "retry"] }
 tower-service = "0.3"
 sync_wrapper = { version = "1.0", features = ["futures"] }
 antidote = "1" 

--- a/src/client/body.rs
+++ b/src/client/body.rs
@@ -129,15 +129,6 @@ impl Body {
         }
     }
 
-    pub(crate) fn try_reuse(self) -> (Option<Bytes>, Self) {
-        let reuse = match self.inner {
-            Inner::Reusable(ref chunk) => Some(chunk.clone()),
-            Inner::Streaming { .. } => None,
-        };
-
-        (reuse, self)
-    }
-
     pub(crate) fn try_clone(&self) -> Option<Body> {
         match self.inner {
             Inner::Reusable(ref chunk) => Some(Body::reusable(chunk.clone())),

--- a/src/client/client/future.rs
+++ b/src/client/client/future.rs
@@ -56,51 +56,6 @@ pin_project! {
     }
 }
 
-impl PendingRequest {
-    fn http2_retry_error(
-        mut self: Pin<&mut Self>,
-        err: &(dyn std::error::Error + 'static),
-    ) -> bool {
-        if !is_http2_retryable_error(err) {
-            return false;
-        }
-
-        trace!(
-            "HTTP/2 retryable error: {:?}, retry_count={}/max={}",
-            err, self.http2_retry_count, self.inner.http2_max_retry_count
-        );
-
-        let body = match self.body {
-            Some(Some(ref body)) => Body::reusable(body.clone()),
-            Some(None) => {
-                debug!("error was retryable, but body not reusable");
-                return false;
-            }
-            None => Body::empty(),
-        };
-
-        if self.http2_retry_count >= self.inner.http2_max_retry_count {
-            trace!("http2 retry count too high: {}", self.http2_retry_count);
-            return false;
-        }
-        self.http2_retry_count += 1;
-
-        *self.as_mut().project().in_flight = {
-            let mut req = http::Request::builder()
-                .uri(self.uri.clone())
-                .method(self.method.clone())
-                .body(body)
-                .expect("valid request parts");
-
-            *req.headers_mut() = self.headers.clone();
-            *req.extensions_mut() = self.extensions.clone();
-            Oneshot::new(self.inner.client.clone(), req)
-        };
-
-        true
-    }
-}
-
 impl Pending {
     pub(crate) fn new_err(err: Error) -> Pending {
         Pending {
@@ -132,14 +87,6 @@ impl Future for PendingRequest {
                 let r = self.as_mut().project().in_flight.get_mut();
                 match Pin::new(r).poll(cx) {
                     Poll::Ready(Err(e)) => {
-                        // Http2 errors are retryable, so we check if we can retry
-                        if let Some(e) = e.source() {
-                            if self.as_mut().http2_retry_error(e) {
-                                continue;
-                            }
-                        }
-
-                        // If the error is an Error, we return it
                         return match e.downcast::<Error>() {
                             Ok(e) => Poll::Ready(Err(*e)),
                             Err(e) => Poll::Ready(Err(error::request(e))),
@@ -162,35 +109,6 @@ impl Future for PendingRequest {
             return Poll::Ready(Ok(res));
         }
     }
-}
-
-fn is_http2_retryable_error(err: &(dyn std::error::Error + 'static)) -> bool {
-    // pop the legacy::Error
-    let err = if let Some(err) = err.source() {
-        err
-    } else {
-        return false;
-    };
-
-    if let Some(cause) = err.source() {
-        if let Some(err) = cause.downcast_ref::<http2::Error>() {
-            // They sent us a graceful shutdown, try with a new connection!
-            if err.is_go_away() && err.is_remote() && err.reason() == Some(http2::Reason::NO_ERROR)
-            {
-                return true;
-            }
-
-            // REFUSED_STREAM was sent from the server, which is safe to retry.
-            // https://www.rfc-editor.org/rfc/rfc9113.html#section-8.7-3.2
-            if err.is_reset()
-                && err.is_remote()
-                && err.reason() == Some(http2::Reason::REFUSED_STREAM)
-            {
-                return true;
-            }
-        }
-    }
-    false
 }
 
 #[cfg(test)]

--- a/src/client/client/future.rs
+++ b/src/client/client/future.rs
@@ -4,8 +4,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use bytes::Bytes;
-use http::{Extensions, HeaderMap, Method, Uri};
+use http::Uri;
 use pin_project_lite::pin_project;
 use tower::util::BoxCloneSyncService;
 use url::Url;
@@ -43,13 +42,8 @@ pub(super) enum PendingInner {
 
 pin_project! {
     pub(super) struct PendingRequest {
-        pub method: Method,
         pub uri: Uri,
         pub url: Url,
-        pub headers: HeaderMap,
-        pub body: Option<Option<Bytes>>,
-        pub extensions: Extensions,
-        pub http2_retry_count: usize,
         pub inner: Arc<ClientRef>,
         #[pin]
         pub in_flight: ResponseFuture,

--- a/src/client/client/future.rs
+++ b/src/client/client/future.rs
@@ -4,7 +4,6 @@ use std::{
     task::{Context, Poll},
 };
 
-use http::Uri;
 use pin_project_lite::pin_project;
 use tower::util::BoxCloneSyncService;
 use url::Url;
@@ -42,7 +41,6 @@ pub(super) enum PendingInner {
 
 pin_project! {
     pub(super) struct PendingRequest {
-        pub uri: Uri,
         pub url: Url,
         pub inner: Arc<ClientRef>,
         #[pin]

--- a/src/client/client/mod.rs
+++ b/src/client/client/mod.rs
@@ -1461,7 +1461,7 @@ impl Client {
         // for both poll_ready and call.
         let in_flight = {
             let mut req = http::Request::builder()
-                .uri(uri.clone())
+                .uri(uri)
                 .method(method.clone())
                 .body(body.unwrap_or_else(Body::empty))
                 .expect("valid request parts");
@@ -1475,7 +1475,6 @@ impl Client {
 
         Pending {
             inner: PendingInner::Request(Box::pin(PendingRequest {
-                uri,
                 url,
                 inner: self.inner.clone(),
                 in_flight,

--- a/src/client/client/mod.rs
+++ b/src/client/client/mod.rs
@@ -398,10 +398,13 @@ impl ClientBuilder {
         }
 
         let service = ServiceBuilder::new()
-            .layer(TimeoutLayer::new(config.timeout, config.read_timeout))
             .layer(RetryLayer::new(Http2RetryPolicy::new(
                 config.http2_max_retry,
             )))
+            .service(service);
+
+        let service = ServiceBuilder::new()
+            .layer(TimeoutLayer::new(config.timeout, config.read_timeout))
             .service(service);
 
         let client_service = ServiceBuilder::new()

--- a/src/client/client/mod.rs
+++ b/src/client/client/mod.rs
@@ -398,10 +398,10 @@ impl ClientBuilder {
         }
 
         let service = ServiceBuilder::new()
+            .layer(TimeoutLayer::new(config.timeout, config.read_timeout))
             .layer(RetryLayer::new(Http2RetryPolicy::new(
                 config.http2_max_retry,
             )))
-            .layer(TimeoutLayer::new(config.timeout, config.read_timeout))
             .service(service);
 
         let client_service = ServiceBuilder::new()

--- a/src/client/client/mod.rs
+++ b/src/client/client/mod.rs
@@ -21,6 +21,7 @@ use http::{
 use service::ClientService;
 use tower::{
     Layer, Service, ServiceBuilder,
+    retry::RetryLayer,
     util::{BoxCloneSyncService, BoxCloneSyncServiceLayer},
 };
 #[cfg(feature = "cookies")]
@@ -42,6 +43,7 @@ use super::{
 use crate::dns::hickory::{HickoryDnsResolver, LookupIpStrategy};
 use crate::{
     IntoUrl, Method, OriginalHeaders, Proxy,
+    client::middleware::retry::Http2RetryPolicy,
     connect::{
         BoxedConnectorLayer, BoxedConnectorService, Connector,
         sealed::{Conn, Unnameable},
@@ -49,19 +51,16 @@ use crate::{
     core::{
         body::Incoming,
         client::{Builder, Client as HyperClient, connect::HttpConnector},
-        ext::{RequestConfig, RequestOriginalHeaders},
         rt::{TokioExecutor, tokio::TokioTimer},
         service::Oneshot,
     },
     dns::{DnsResolverWithOverrides, DynResolver, Resolve, gai::GaiResolver},
-    error,
-    error::{BoxError, Error},
+    error::{self, BoxError, Error},
     http1::Http1Config,
     http2::Http2Config,
     into_url::try_uri,
     proxy::Matcher as ProxyMatcher,
-    redirect,
-    redirect::TowerRedirectPolicy,
+    redirect::{self, TowerRedirectPolicy},
     tls::{
         AlpnProtos, CertStore, CertificateInput, Identity, KeyLogPolicy, TlsConfig, TlsConnector,
         TlsVersion,
@@ -100,10 +99,8 @@ pub struct Client {
 struct ClientRef {
     accepts: Accepts,
     headers: HeaderMap,
-    original_headers: RequestConfig<RequestOriginalHeaders>,
     client: BoxedClientService,
     https_only: bool,
-    http2_max_retry_count: usize,
     proxies: Arc<Vec<ProxyMatcher>>,
     proxies_maybe_http_auth: bool,
     proxies_maybe_http_custom_headers: bool,
@@ -161,7 +158,7 @@ struct Config {
     https_only: bool,
     http1_config: Http1Config,
     http2_config: Http2Config,
-    http2_max_retry_count: usize,
+    http2_max_retry: usize,
     request_layers: Option<Vec<BoxedClientServiceLayer>>,
     connector_layers: Option<Vec<BoxedConnectorLayer>>,
     builder: Builder,
@@ -239,7 +236,7 @@ impl ClientBuilder {
                 https_only: false,
                 http1_config: Http1Config::default(),
                 http2_config: Http2Config::default(),
-                http2_max_retry_count: 2,
+                http2_max_retry: 2,
                 request_layers: None,
                 connector_layers: None,
                 alpn_protos: None,
@@ -373,7 +370,10 @@ impl ClientBuilder {
                     config.timeout,
                     config.read_timeout,
                 ))
-                .service(ClientService::new(config.builder.build(connector)));
+                .service(ClientService::new(
+                    config.builder.build(connector),
+                    config.original_headers,
+                ));
 
             #[cfg(feature = "cookies")]
             let service = ServiceBuilder::new()
@@ -398,6 +398,9 @@ impl ClientBuilder {
         }
 
         let service = ServiceBuilder::new()
+            .layer(RetryLayer::new(Http2RetryPolicy::new(
+                config.http2_max_retry,
+            )))
             .layer(TimeoutLayer::new(config.timeout, config.read_timeout))
             .service(service);
 
@@ -410,9 +413,7 @@ impl ClientBuilder {
                 accepts: config.accepts,
                 client: BoxCloneSyncService::new(client_service),
                 headers: config.headers,
-                original_headers: RequestConfig::new(config.original_headers),
                 https_only: config.https_only,
-                http2_max_retry_count: config.http2_max_retry_count,
                 proxies_maybe_http_auth,
                 proxies_maybe_http_custom_headers,
                 proxies,
@@ -854,8 +855,8 @@ impl ClientBuilder {
     }
 
     /// Sets the maximum number of safe retries for HTTP/2 connections.
-    pub fn http2_max_retry_count(mut self, max: usize) -> ClientBuilder {
-        self.config.http2_max_retry_count = max;
+    pub fn http2_max_retry(mut self, max: usize) -> ClientBuilder {
+        self.config.http2_max_retry = max;
         self
     }
 
@@ -1408,7 +1409,7 @@ impl Client {
     }
 
     pub(super) fn execute_request(&self, req: Request) -> Pending {
-        let (method, url, mut headers, body, mut extensions, _allow_compression) = req.pieces();
+        let (method, url, mut headers, body, extensions, _allow_compression) = req.pieces();
 
         // get the scheme of the URL
         let scheme = url.scheme();
@@ -1470,9 +1471,6 @@ impl Client {
                 .method(method.clone())
                 .body(body)
                 .expect("valid request parts");
-
-            // Inject metadata into request extensions
-            self.inner.original_headers.replace_to(&mut extensions);
 
             // Finalize headers and extensions
             *req.headers_mut() = headers.clone();

--- a/src/client/client/service.rs
+++ b/src/client/client/service.rs
@@ -1,5 +1,6 @@
 use std::{
     pin::Pin,
+    sync::Arc,
     task::{Context, Poll},
 };
 
@@ -8,20 +9,29 @@ use tower::Service;
 
 use super::Body;
 use crate::{
+    OriginalHeaders,
     connect::Connector,
-    core::{body::Incoming, client::Client},
+    core::{
+        body::Incoming,
+        client::Client,
+        ext::{RequestConfig, RequestOriginalHeaders},
+    },
     error::{self, BoxError},
 };
 
 #[derive(Clone)]
 pub struct ClientService {
     client: Client<Connector, Body>,
+    original_headers: Arc<RequestConfig<RequestOriginalHeaders>>,
 }
 
 impl ClientService {
     #[inline(always)]
-    pub fn new(client: Client<Connector, Body>) -> Self {
-        Self { client }
+    pub fn new(client: Client<Connector, Body>, original_headers: Option<OriginalHeaders>) -> Self {
+        Self {
+            client,
+            original_headers: Arc::new(RequestConfig::new(original_headers)),
+        }
     }
 }
 
@@ -37,9 +47,10 @@ impl Service<Request<Body>> for ClientService {
             .map_err(From::from)
     }
 
-    fn call(&mut self, req: Request<Body>) -> Self::Future {
+    fn call(&mut self, mut req: Request<Body>) -> Self::Future {
         let clone = self.client.clone();
         let mut inner = std::mem::replace(&mut self.client, clone);
+        self.original_headers.replace_to(req.extensions_mut());
         Box::pin(async move {
             inner
                 .call(req)

--- a/src/client/middleware/mod.rs
+++ b/src/client/middleware/mod.rs
@@ -3,4 +3,5 @@
 #[cfg(feature = "cookies")]
 pub mod cookie;
 pub mod redirect;
+pub mod retry;
 pub mod timeout;

--- a/src/client/middleware/retry/mod.rs
+++ b/src/client/middleware/retry/mod.rs
@@ -10,7 +10,7 @@ use crate::{
 pub struct Http2RetryPolicy(usize);
 
 impl Http2RetryPolicy {
-    /// Create a new `Http2Attempts` policy with the specified number of attempts.
+    /// Create a new `Http2RetryPolicy` policy with the specified number of attempts.
     pub const fn new(attempts: usize) -> Self {
         Self(attempts)
     }

--- a/src/client/middleware/retry/mod.rs
+++ b/src/client/middleware/retry/mod.rs
@@ -82,11 +82,16 @@ impl Policy<Req, Res, BoxError> for Http2RetryPolicy {
     }
 
     fn clone_request(&mut self, req: &Req) -> Option<Req> {
-        Request::builder()
+        let mut new_req = Request::builder()
             .method(req.method().clone())
             .uri(req.uri().clone())
             .version(req.version())
             .body(req.body().try_clone()?)
-            .ok()
+            .ok()?;
+
+        *new_req.headers_mut() = req.headers().clone();
+        *new_req.extensions_mut() = req.extensions().clone();
+
+        Some(new_req)
     }
 }

--- a/src/client/middleware/retry/mod.rs
+++ b/src/client/middleware/retry/mod.rs
@@ -1,0 +1,92 @@
+use futures_util::future;
+use http::{Request, Response};
+use tower::retry::Policy;
+
+use crate::{
+    Body, client::middleware::timeout::TimeoutBody, core::body::Incoming, error::BoxError,
+};
+
+#[derive(Clone)]
+pub struct Http2RetryPolicy(usize);
+
+impl Http2RetryPolicy {
+    /// Create a new `Http2Attempts` policy with the specified number of attempts.
+    pub const fn new(attempts: usize) -> Self {
+        Self(attempts)
+    }
+
+    fn is_retryable_error(&self, err: &(dyn std::error::Error + 'static)) -> bool {
+        // pop the legacy::Error
+        let err = if let Some(err) = err.source() {
+            err
+        } else {
+            return false;
+        };
+
+        if let Some(cause) = err.source() {
+            if let Some(err) = cause.downcast_ref::<http2::Error>() {
+                // They sent us a graceful shutdown, try with a new connection!
+                if err.is_go_away()
+                    && err.is_remote()
+                    && err.reason() == Some(http2::Reason::NO_ERROR)
+                {
+                    return true;
+                }
+
+                // REFUSED_STREAM was sent from the server, which is safe to retry.
+                // https://www.rfc-editor.org/rfc/rfc9113.html#section-8.7-3.2
+                if err.is_reset()
+                    && err.is_remote()
+                    && err.reason() == Some(http2::Reason::REFUSED_STREAM)
+                {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+}
+
+type Req = Request<Body>;
+type Res = Response<TimeoutBody<Incoming>>;
+
+impl Policy<Req, Res, BoxError> for Http2RetryPolicy {
+    type Future = future::Ready<()>;
+
+    fn retry(
+        &mut self,
+        _req: &mut Req,
+        result: &mut Result<Res, BoxError>,
+    ) -> Option<Self::Future> {
+        if let Err(err) = result {
+            if let Some(source) = err.source() {
+                if self.is_retryable_error(source) {
+                    return Some(future::ready(()));
+                }
+            }
+
+            // Treat all errors as failures...
+            // But we limit the number of attempts...
+            return if self.0 > 0 {
+                trace!("Retrying HTTP/2 request, attempts left: {}", self.0);
+                // Try again!
+                self.0 -= 1;
+                Some(future::ready(()))
+            } else {
+                // Used all our attempts, no retry...
+                None
+            };
+        }
+
+        None
+    }
+
+    fn clone_request(&mut self, req: &Req) -> Option<Req> {
+        Request::builder()
+            .method(req.method().clone())
+            .uri(req.uri().clone())
+            .version(req.version())
+            .body(req.body().try_clone()?)
+            .ok()
+    }
+}


### PR DESCRIPTION
close: https://github.com/0x676e67/wreq/issues/706