### PR TITLE
refactor(proxy): Remove support for `Proxy::custom`

### DIFF
--- a/examples/connect_via_lower_priority_tokio_runtime.rs
+++ b/examples/connect_via_lower_priority_tokio_runtime.rs
@@ -1,4 +1,3 @@
-#![deny(warnings)]
 // This example demonstrates how to delegate the connect calls, which contain TLS handshakes,
 // to a secondary tokio runtime of lower OS thread priority using a custom tower layer.
 // This helps to ensure that long-running futures during handshake crypto operations don't block
@@ -84,7 +83,7 @@ mod background_threadpool {
                                 *libc::__errno_location() = 0;
                                 if libc::nice(10) == -1 && *libc::__errno_location() != 0 {
                                     let error = std::io::Error::last_os_error();
-                                    log::error!("failed to set threadpool niceness: {}", error);
+                                    log::error!("failed to set threadpool niceness: {error}");
                                 }
                             }
                         }

--- a/examples/connect_via_lower_priority_tokio_runtime.rs
+++ b/examples/connect_via_lower_priority_tokio_runtime.rs
@@ -91,13 +91,13 @@ mod background_threadpool {
                     })
                     .enable_all()
                     .build()
-                    .unwrap_or_else(|e| panic!("cpu heavy runtime failed_to_initialize: {}", e));
+                    .unwrap_or_else(|e| panic!("cpu heavy runtime failed_to_initialize: {e}"));
                 rt.block_on(async {
                     log::debug!("starting background cpu-heavy work");
                     process_cpu_work().await;
                 });
             })
-            .unwrap_or_else(|e| panic!("cpu heavy thread failed_to_initialize: {}", e));
+            .unwrap_or_else(|e| panic!("cpu heavy thread failed_to_initialize: {e}"));
     }
 
     async fn process_cpu_work() {

--- a/examples/hickory_dns.rs
+++ b/examples/hickory_dns.rs
@@ -25,7 +25,7 @@ async fn main() -> wreq::Result<()> {
         .text()
         .await?;
 
-    println!("{}", text);
+    println!("{text}");
 
     Ok(())
 }

--- a/examples/http1_case_sensitive_headers.rs
+++ b/examples/http1_case_sensitive_headers.rs
@@ -26,7 +26,7 @@ async fn main() -> wreq::Result<()> {
         .text()
         .await?;
 
-    println!("{}", resp);
+    println!("{resp}");
 
     Ok(())
 }

--- a/examples/json_dynamic.rs
+++ b/examples/json_dynamic.rs
@@ -21,7 +21,7 @@ async fn main() -> wreq::Result<()> {
         .json()
         .await?;
 
-    println!("{:#?}", echo_json);
+    println!("{echo_json:#?}");
     // Object(
     //     {
     //         "body": String(

--- a/examples/json_typed.rs
+++ b/examples/json_typed.rs
@@ -35,7 +35,7 @@ async fn main() -> wreq::Result<()> {
         .json()
         .await?;
 
-    println!("{:#?}", new_post);
+    println!("{new_post:#?}");
     // Post {
     //     id: Some(
     //         101

--- a/examples/request_with_interface.rs
+++ b/examples/request_with_interface.rs
@@ -22,7 +22,7 @@ async fn main() -> wreq::Result<()> {
         .text()
         .await?;
 
-    println!("{}", text);
+    println!("{text}");
 
     Ok(())
 }

--- a/examples/request_with_proxy.rs
+++ b/examples/request_with_proxy.rs
@@ -14,7 +14,7 @@ async fn main() -> wreq::Result<()> {
         .text()
         .await?;
 
-    println!("{}", resp);
+    println!("{resp}");
 
     Ok(())
 }

--- a/examples/request_with_redirect.rs
+++ b/examples/request_with_redirect.rs
@@ -14,7 +14,7 @@ async fn main() -> wreq::Result<()> {
         .text()
         .await?;
 
-    println!("{}", resp);
+    println!("{resp}");
 
     Ok(())
 }

--- a/examples/set_cert_store.rs
+++ b/examples/set_cert_store.rs
@@ -46,7 +46,7 @@ async fn use_static_root_certs() -> wreq::Result<()> {
         .text()
         .await?;
 
-    println!("{}", text);
+    println!("{text}");
 
     Ok(())
 }
@@ -63,7 +63,7 @@ async fn use_system_root_certs() -> wreq::Result<()> {
         .text()
         .await?;
 
-    println!("{}", text);
+    println!("{text}");
 
     Ok(())
 }

--- a/examples/tor_socks.rs
+++ b/examples/tor_socks.rs
@@ -17,7 +17,7 @@ async fn main() -> wreq::Result<()> {
 
     let text = res.text().await?;
     let is_tor = text.contains("Congratulations. This emulation is configured to use Tor.");
-    println!("Is Tor: {}", is_tor);
+    println!("Is Tor: {is_tor}");
     assert!(is_tor);
 
     Ok(())

--- a/src/client/request.rs
+++ b/src/client/request.rs
@@ -421,7 +421,7 @@ impl RequestBuilder {
     where
         T: fmt::Display,
     {
-        let header_value = format!("Bearer {}", token);
+        let header_value = format!("Bearer {token}");
         self.header_operation(
             crate::header::AUTHORIZATION,
             header_value,

--- a/src/client/websocket/mod.rs
+++ b/src/client/websocket/mod.rs
@@ -322,8 +322,7 @@ impl WebSocketRequestBuilder {
             }
             _ => {
                 return Err(Error::upgrade(format!(
-                    "unsupported version: {:?}",
-                    version
+                    "unsupported version: {version:?}"
                 )));
             }
         };
@@ -406,7 +405,7 @@ impl WebSocketResponse {
                 Version::HTTP_10 | Version::HTTP_11 => {
                     if status != StatusCode::SWITCHING_PROTOCOLS {
                         let body = self.inner.text().await?;
-                        return Err(Error::upgrade(format!("unexpected status code: {}", body)));
+                        return Err(Error::upgrade(format!("unexpected status code: {body}")));
                     }
 
                     if !header_contains(self.inner.headers(), header::CONNECTION, "upgrade") {
@@ -426,8 +425,7 @@ impl WebSocketResponse {
                                 s == tungstenite::handshake::derive_accept_key(nonce.as_bytes())
                             }) {
                                 return Err(Error::upgrade(format!(
-                                    "invalid accept key: {:?}",
-                                    header
+                                    "invalid accept key: {header:?}"
                                 )));
                             }
                         }
@@ -439,8 +437,7 @@ impl WebSocketResponse {
                 Version::HTTP_2 => {
                     if status != StatusCode::OK {
                         return Err(Error::upgrade(format!(
-                            "unexpected status code: {}",
-                            status
+                            "unexpected status code: {status}"
                         )));
                     }
                 }
@@ -471,7 +468,7 @@ impl WebSocketResponse {
                     {
                         if !protocols.contains(&Cow::Borrowed(protocol)) {
                             // the responded protocol is none which we requested
-                            return Err(Error::upgrade(format!("invalid protocol: {}", protocol)));
+                            return Err(Error::upgrade(format!("invalid protocol: {protocol}")));
                         }
                     } else {
                         // we didn't request any protocols but got one anyway

--- a/src/client/websocket/mod.rs
+++ b/src/client/websocket/mod.rs
@@ -321,9 +321,7 @@ impl WebSocketRequestBuilder {
                 None
             }
             _ => {
-                return Err(Error::upgrade(format!(
-                    "unsupported version: {version:?}"
-                )));
+                return Err(Error::upgrade(format!("unsupported version: {version:?}")));
             }
         };
 
@@ -436,9 +434,7 @@ impl WebSocketResponse {
                 }
                 Version::HTTP_2 => {
                     if status != StatusCode::OK {
-                        return Err(Error::upgrade(format!(
-                            "unexpected status code: {status}"
-                        )));
+                        return Err(Error::upgrade(format!("unexpected status code: {status}")));
                     }
                 }
                 _ => {

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -1002,7 +1002,7 @@ mod verbose {
                     } else if (0x20..0x7f).contains(&c) {
                         write!(f, "{}", c as char)?;
                     } else {
-                        write!(f, "\\x{:02x}", c)?;
+                        write!(f, "\\x{c:02x}")?;
                     }
                 }
                 write!(f, "\"")?;

--- a/src/core/body/incoming.rs
+++ b/src/core/body/incoming.rs
@@ -380,9 +380,7 @@ mod tests {
         let body_expected_size = mem::size_of::<u64>() * 5;
         assert!(
             body_size <= body_expected_size,
-            "Body size = {} <= {}",
-            body_size,
-            body_expected_size,
+            "Body size = {body_size} <= {body_expected_size}",
         );
 
         //assert_eq!(body_size, mem::size_of::<Option<Incoming>>(), "Option<Incoming>");
@@ -404,8 +402,8 @@ mod tests {
     fn size_hint() {
         fn eq(body: Incoming, b: SizeHint, note: &str) {
             let a = body.size_hint();
-            assert_eq!(a.lower(), b.lower(), "lower for {:?}", note);
-            assert_eq!(a.upper(), b.upper(), "upper for {:?}", note);
+            assert_eq!(a.lower(), b.lower(), "lower for {note:?}");
+            assert_eq!(a.upper(), b.upper(), "upper for {note:?}");
         }
 
         eq(Incoming::empty(), SizeHint::with_exact(0), "empty");
@@ -427,7 +425,7 @@ mod tests {
         tx.abort();
 
         let err = rx.frame().await.unwrap().unwrap_err();
-        assert!(err.is_body_write_aborted(), "{:?}", err);
+        assert!(err.is_body_write_aborted(), "{err:?}");
     }
 
     #[cfg(not(miri))]
@@ -449,7 +447,7 @@ mod tests {
         assert_eq!(chunk1, "chunk 1");
 
         let err = rx.frame().await.unwrap().unwrap_err();
-        assert!(err.is_body_write_aborted(), "{:?}", err);
+        assert!(err.is_body_write_aborted(), "{err:?}");
     }
 
     #[test]
@@ -519,7 +517,7 @@ mod tests {
 
         match tx_ready.poll() {
             Poll::Ready(Err(ref e)) if e.is_closed() => (),
-            unexpected => panic!("tx poll ready unexpected: {:?}", unexpected),
+            unexpected => panic!("tx poll ready unexpected: {unexpected:?}"),
         }
     }
 }

--- a/src/core/body/length.rs
+++ b/src/core/body/length.rs
@@ -89,7 +89,7 @@ impl fmt::Display for DecodedLength {
             DecodedLength::CLOSE_DELIMITED => f.write_str("close-delimited"),
             DecodedLength::CHUNKED => f.write_str("chunked encoding"),
             DecodedLength::ZERO => f.write_str("empty"),
-            DecodedLength(n) => write!(f, "content-length ({} bytes)", n),
+            DecodedLength(n) => write!(f, "content-length ({n} bytes)"),
         }
     }
 }

--- a/src/core/client/connect/dns.rs
+++ b/src/core/client/connect/dns.rs
@@ -154,7 +154,7 @@ impl Future for GaiFuture {
                 if join_err.is_cancelled() {
                     Err(io::Error::new(io::ErrorKind::Interrupted, join_err))
                 } else {
-                    panic!("gai background task failed: {:?}", join_err)
+                    panic!("gai background task failed: {join_err:?}")
                 }
             }
         })

--- a/src/core/client/connect/proxy/tunnel.rs
+++ b/src/core/client/connect/proxy/tunnel.rs
@@ -280,7 +280,7 @@ mod tests {
         let tcp = TcpListener::bind("127.0.0.1:0").await.expect("bind");
         let addr = tcp.local_addr().expect("local_addr");
 
-        let proxy_dst = format!("http://{}", addr).parse().expect("uri");
+        let proxy_dst = format!("http://{addr}").parse().expect("uri");
         let mut connector = Tunnel::new(proxy_dst, HttpConnector::new());
         let t1 = tokio::spawn(async move {
             let _conn = connector

--- a/src/core/client/dst.rs
+++ b/src/core/client/dst.rs
@@ -49,7 +49,7 @@ impl Dst {
                 return Err(Error {
                     kind: ErrorKind::UserAbsoluteUriRequired,
                     source: Some(
-                        format!("Client requires absolute-form URIs, received: {:?}", uri).into(),
+                        format!("Client requires absolute-form URIs, received: {uri:?}").into(),
                     ),
                     connect_info: None,
                 });

--- a/src/core/client/dst.rs
+++ b/src/core/client/dst.rs
@@ -11,7 +11,7 @@ use crate::{
         RequestConfig, RequestHttpVersionPref, RequestInterface, RequestIpv4Addr, RequestIpv6Addr,
         RequestProxyMatcher,
     },
-    proxy::Intercepted,
+    proxy::Matcher as ProxyMatcher,
     tls::AlpnProtocol,
 };
 
@@ -71,7 +71,7 @@ impl Dst {
         let local_ipv4_address = RequestConfig::<RequestIpv4Addr>::remove(extensions);
         let local_ipv6_address = RequestConfig::<RequestIpv6Addr>::remove(extensions);
         let interface = RequestConfig::<RequestInterface>::remove(extensions);
-        let proxy_scheme = RequestConfig::<RequestProxyMatcher>::remove(extensions);
+        let proxy_matcher = RequestConfig::<RequestProxyMatcher>::remove(extensions);
 
         // Convert the scheme and host to a URI
         Uri::builder()
@@ -80,14 +80,13 @@ impl Dst {
             .path_and_query(PathAndQuery::from_static("/"))
             .build()
             .map(|uri| {
-                let proxy_intercepted = proxy_scheme.and_then(|matcher| matcher.intercept(&uri));
                 Dst((
                     uri,
                     alpn,
                     local_ipv4_address,
                     local_ipv6_address,
                     interface,
-                    proxy_intercepted,
+                    proxy_matcher,
                 ))
             })
             .map_err(Into::into)
@@ -137,7 +136,7 @@ impl Dst {
     }
 
     #[inline(always)]
-    pub(crate) fn take_proxy_intercepted(&mut self) -> Option<Intercepted> {
+    pub(crate) fn take_proxy_matcher(&mut self) -> Option<ProxyMatcher> {
         self.0.5.take()
     }
 

--- a/src/core/client/mod.rs
+++ b/src/core/client/mod.rs
@@ -320,7 +320,7 @@ where
                 req.headers_mut().entry(HOST).or_insert_with(|| {
                     let hostname = uri.host().expect("authority implies host");
                     if let Some(port) = get_non_default_port(&uri) {
-                        let s = format!("{}:{}", hostname, port);
+                        let s = format!("{hostname}:{port}");
                         HeaderValue::from_str(&s)
                     } else {
                         HeaderValue::from_str(hostname)

--- a/src/core/client/mod.rs
+++ b/src/core/client/mod.rs
@@ -45,7 +45,7 @@ use crate::{
         error::BoxError,
         rt::Timer,
     },
-    proxy::Intercepted,
+    proxy::Matcher as ProxyMacher,
     tls::AlpnProtocol,
 };
 
@@ -139,7 +139,7 @@ type PoolKey = (
     Option<Ipv4Addr>,
     Option<Ipv6Addr>,
     Option<Cow<'static, str>>,
-    Option<Intercepted>,
+    Option<ProxyMacher>,
 );
 
 #[allow(clippy::large_enum_variant)]

--- a/src/core/proto/h1/decode.rs
+++ b/src/core/proto/h1/decode.rs
@@ -759,7 +759,7 @@ mod tests {
                     )
                 })
                 .await;
-                let desc = format!("read_size failed for {:?}", s);
+                let desc = format!("read_size failed for {s:?}");
                 state = result.expect(&desc);
                 if state == ChunkedState::Body || state == ChunkedState::EndCr {
                     break;
@@ -803,7 +803,7 @@ mod tests {
                     }
                 };
                 if state == ChunkedState::Body || state == ChunkedState::End {
-                    panic!("Was Ok. Expected Err for {:?}", s);
+                    panic!("Was Ok. Expected Err for {s:?}");
                 }
             }
         }
@@ -1087,7 +1087,7 @@ mod tests {
         let mut scratch = vec![];
         scratch.extend(b"10\r\n1234567890abcdef\r\n0\r\n");
         for i in 0..h1_max_headers {
-            scratch.extend(format!("trailer{}: {}\r\n", i, i).as_bytes());
+            scratch.extend(format!("trailer{i}: {i}\r\n").as_bytes());
         }
         scratch.extend(b"\r\n");
         let mut mock_buf = Bytes::from(scratch);

--- a/src/core/proto/h1/dispatch.rs
+++ b/src/core/proto/h1/dispatch.rs
@@ -623,7 +623,7 @@ mod tests {
 
             match (err.error.is_canceled(), err.message.as_ref()) {
                 (true, Some(_)) => (),
-                _ => panic!("expected Canceled, got {:?}", err),
+                _ => panic!("expected Canceled, got {err:?}"),
             }
         });
     }

--- a/src/core/proto/h1/encode.rs
+++ b/src/core/proto/h1/encode.rs
@@ -336,7 +336,7 @@ impl ChunkSize {
             pos: 0,
             len: 0,
         };
-        write!(&mut size, "{:X}\r\n", len).expect("CHUNK_SIZE_MAX_BYTES should fit any usize");
+        write!(&mut size, "{len:X}\r\n").expect("CHUNK_SIZE_MAX_BYTES should fit any usize");
         size
     }
 }
@@ -553,19 +553,7 @@ mod tests {
         let encoder = Encoder::chunked();
 
         let trailers = format!(
-            "{},{},{},{},{},{},{},{},{},{},{},{}",
-            AUTHORIZATION,
-            CACHE_CONTROL,
-            CONTENT_ENCODING,
-            CONTENT_LENGTH,
-            CONTENT_RANGE,
-            CONTENT_TYPE,
-            HOST,
-            MAX_FORWARDS,
-            SET_COOKIE,
-            TRAILER,
-            TRANSFER_ENCODING,
-            TE,
+            "{AUTHORIZATION},{CACHE_CONTROL},{CONTENT_ENCODING},{CONTENT_LENGTH},{CONTENT_RANGE},{CONTENT_TYPE},{HOST},{MAX_FORWARDS},{SET_COOKIE},{TRAILER},{TRANSFER_ENCODING},{TE}",
         );
         let trailers = vec![HeaderValue::from_str(&trailers).unwrap()];
         let encoder = encoder.into_chunked_with_trailing_fields(trailers);

--- a/src/core/proto/h1/io.rs
+++ b/src/core/proto/h1/io.rs
@@ -79,8 +79,7 @@ where
     pub(crate) fn set_max_buf_size(&mut self, max: usize) {
         assert!(
             max >= MINIMUM_MAX_BUFFER_SIZE,
-            "The max_buf_size cannot be smaller than {}.",
-            MINIMUM_MAX_BUFFER_SIZE,
+            "The max_buf_size cannot be smaller than {MINIMUM_MAX_BUFFER_SIZE}.",
         );
         self.read_buf_strategy = ReadStrategy::with_max(max);
         self.write_buf.max_buf_size = max;
@@ -794,9 +793,7 @@ mod tests {
                 next = strategy.next();
                 assert!(
                     next.is_power_of_two(),
-                    "decrement should be powers of two: {} (max = {})",
-                    next,
-                    max,
+                    "decrement should be powers of two: {next} (max = {max})",
                 );
             }
         }

--- a/src/core/proto/h1/role.rs
+++ b/src/core/proto/h1/role.rs
@@ -289,7 +289,7 @@ impl Http1Transaction for Client {
                 debug!("request with HTTP2 version coerced to HTTP/1.1");
                 extend(dst, b"HTTP/1.1");
             }
-            other => panic!("unexpected request version: {:?}", other),
+            other => panic!("unexpected request version: {other:?}"),
         }
         extend(dst, b"\r\n");
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -282,7 +282,7 @@ impl fmt::Display for Error {
                     debug_assert!(code.is_server_error());
                     "HTTP status server error"
                 };
-                write!(f, "{} ({})", prefix, code)?;
+                write!(f, "{prefix} ({code})")?;
             }
         };
 
@@ -291,7 +291,7 @@ impl fmt::Display for Error {
         }
 
         if let Some(e) = &self.inner.source {
-            write!(f, ": {}", e)?;
+            write!(f, ": {e}")?;
         }
 
         Ok(())
@@ -333,7 +333,7 @@ impl From<serde_json::Error> for Error {
 
 impl From<boring2::error::ErrorStack> for Error {
     fn from(err: boring2::error::ErrorStack) -> Error {
-        Error::new(Kind::Builder, Some(format!("boring tls error: {:?}", err)))
+        Error::new(Kind::Builder, Some(format!("boring tls error: {err:?}")))
     }
 }
 
@@ -428,7 +428,7 @@ mod tests {
         // It should have pulled out the original, not nested it...
         match err.inner.kind {
             Kind::Request => (),
-            _ => panic!("{:?}", err),
+            _ => panic!("{err:?}"),
         }
     }
 
@@ -438,7 +438,7 @@ mod tests {
         let err = decode_io(orig);
         match err.inner.kind {
             Kind::Decode => (),
-            _ => panic!("{:?}", err),
+            _ => panic!("{err:?}"),
         }
     }
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -16,7 +16,6 @@
 pub use fallback::MutexGuard;
 #[cfg(not(feature = "parking_lot"))]
 pub use fallback::{Mutex, RwLock};
-
 #[cfg(all(feature = "parking_lot", test))]
 pub use parking_lot::MutexGuard;
 #[cfg(feature = "parking_lot")]

--- a/src/tls/keylog/handle.rs
+++ b/src/tls/keylog/handle.rs
@@ -19,8 +19,7 @@ impl KeyLogHandle {
         if let Some(parent) = filepath.parent() {
             std::fs::create_dir_all(parent).map_err(|err| {
                 Error::other(format!(
-                    "KeyLogHandle: Failed to create keylog parent path directory: {}",
-                    err
+                    "KeyLogHandle: Failed to create keylog parent path directory: {err}"
                 ))
             })?;
         }
@@ -57,7 +56,7 @@ impl KeyLogHandle {
 
     /// Write a line to the keylogger.
     pub fn write_log_line(&self, line: &str) {
-        let line = format!("{}\n", line);
+        let line = format!("{line}\n");
         if let Err(_err) = self.sender.send(line) {
             error!(
                 file = ?self.filepath,

--- a/src/tls/keylog/mod.rs
+++ b/src/tls/keylog/mod.rs
@@ -43,8 +43,7 @@ impl KeyLogPolicy {
                     Error::new(
                         ErrorKind::NotFound,
                         format!(
-                            "KeyLogPolicy: SSLKEYLOGFILE environment is invalid: {}",
-                            err
+                            "KeyLogPolicy: SSLKEYLOGFILE environment is invalid: {err}"
                         ),
                     )
                 })?,

--- a/src/tls/keylog/mod.rs
+++ b/src/tls/keylog/mod.rs
@@ -42,9 +42,7 @@ impl KeyLogPolicy {
                 .map_err(|err| {
                     Error::new(
                         ErrorKind::NotFound,
-                        format!(
-                            "KeyLogPolicy: SSLKEYLOGFILE environment is invalid: {err}"
-                        ),
+                        format!("KeyLogPolicy: SSLKEYLOGFILE environment is invalid: {err}"),
                     )
                 })?,
             KeyLogPolicy::File(keylog_filename) => normalize_path(keylog_filename),

--- a/src/util.rs
+++ b/src/util.rs
@@ -12,9 +12,9 @@ where
     let mut buf = b"Basic ".to_vec();
     {
         let mut encoder = EncoderWriter::new(&mut buf, &BASE64_STANDARD);
-        let _ = write!(encoder, "{}:", username);
+        let _ = write!(encoder, "{username}:");
         if let Some(password) = password {
-            let _ = write!(encoder, "{}", password);
+            let _ = write!(encoder, "{password}");
         }
     }
     let mut header = HeaderValue::from_bytes(&buf).expect("base64 is always valid HeaderValue");

--- a/tests/badssl.rs
+++ b/tests/badssl.rs
@@ -86,7 +86,7 @@ async fn test_3des_support() -> wreq::Result<()> {
         .text()
         .await?;
 
-    println!("3des.badssl.com is supported:\n{}", content);
+    println!("3des.badssl.com is supported:\n{content}");
 
     Ok(())
 }
@@ -121,7 +121,7 @@ async fn test_firefox_7x_100_cipher() -> wreq::Result<()> {
         .text()
         .await?;
 
-    println!("dh2048.badssl.com is supported:\n{}", content);
+    println!("dh2048.badssl.com is supported:\n{content}");
 
     Ok(())
 }

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -303,8 +303,7 @@ async fn tunnel_detects_auth_required() {
     let err = support::error::inspect(err).pop().unwrap();
     assert!(
         err.contains("auth"),
-        "proxy auth err expected, got: {:?}",
-        err
+        "proxy auth err expected, got: {err:?}"
     );
 }
 
@@ -342,8 +341,7 @@ async fn tunnel_includes_proxy_auth() {
     let err = support::error::inspect(err).pop().unwrap();
     assert!(
         err.contains("unsuccessful"),
-        "tunnel unsuccessful expected, got: {:?}",
-        err
+        "tunnel unsuccessful expected, got: {err:?}"
     );
 }
 
@@ -383,7 +381,6 @@ async fn tunnel_includes_user_agent() {
     let err = support::error::inspect(err).pop().unwrap();
     assert!(
         err.contains("unsuccessful"),
-        "tunnel unsuccessful expected, got: {:?}",
-        err
+        "tunnel unsuccessful expected, got: {err:?}"
     );
 }

--- a/tests/support/server.rs
+++ b/tests/support/server.rs
@@ -79,8 +79,7 @@ where
         let (panic_tx, panic_rx) = std_mpsc::channel();
         let (events_tx, events_rx) = std_mpsc::channel();
         let tname = format!(
-            "test({})-support-server",
-            test_name,
+            "test({test_name})-support-server",
         );
         thread::Builder::new()
             .name(tname)
@@ -151,7 +150,7 @@ where
         let (shutdown_tx, mut shutdown_rx) = oneshot::channel();
         let (panic_tx, panic_rx) = std_mpsc::channel();
         let (events_tx, events_rx) = std_mpsc::channel();
-        let tname = format!("test({})-support-server", test_name,);
+        let tname = format!("test({test_name})-support-server",);
         thread::Builder::new()
             .name(tname)
             .spawn(move || {

--- a/tests/zstd.rs
+++ b/tests/zstd.rs
@@ -427,7 +427,7 @@ async fn test_chunked_fragmented_multiple_frames_in_one_chunk() {
                 COMPRESSED_RESPONSE_HEADERS, /* e.g., "HTTP/1.1 200 OK\r\nContent-Encoding:
                                               * zstd\r\n" */
                 b"Transfer-Encoding: chunked\r\n\r\n", // Indicate chunked encoding
-                format!("{:x}\r\n", chunk_size).as_bytes(), // Chunk size in hex
+                format!("{chunk_size:x}\r\n").as_bytes(), // Chunk size in hex
             ]
             .concat();
 
@@ -503,7 +503,7 @@ async fn test_connection_reuse_with_chunked_fragmented_multiple_frames_in_one_ch
                 COMPRESSED_RESPONSE_HEADERS, /* e.g., "HTTP/1.1 200 OK\r\nContent-Encoding:
                                               * zstd\r\n" */
                 b"Transfer-Encoding: chunked\r\n\r\n", // Indicate chunked encoding
-                format!("{:x}\r\n", chunk_size).as_bytes(), // Chunk size in hex
+                format!("{chunk_size:x}\r\n").as_bytes(), // Chunk size in hex
             ]
             .concat();
 
@@ -571,7 +571,6 @@ async fn test_connection_reuse_with_chunked_fragmented_multiple_frames_in_one_ch
     let first_addr = peer_addrs[0];
     assert!(
         peer_addrs.iter().all(|addr| addr == &first_addr),
-        "All peer addresses should be the same, but found differences: {:?}",
-        peer_addrs
+        "All peer addresses should be the same, but found differences: {peer_addrs:?}"
     );
 }


### PR DESCRIPTION
The current implementation already supports request-level proxies, which makes Proxy::custom largely redundant.
Due to the design of the connection pool (PoolKey) differentiating proxies, enabling the pool means each request using Proxy::custom incurs an unnecessary match operation.
This is because custom accepts a closure, which cannot be hashed, and must therefore be executed to obtain the proxy credentials.

Even in reqwest’s design, when Proxy::custom is used with connection pooling, the proxy is only matched once and then reused, since reqwest’s PoolKey only considers the target URI as its identifier.