### PR TITLE
chore: remove unused `#[allow]` attributes

### DIFF
--- a/src/client/ws/json.rs
+++ b/src/client/ws/json.rs
@@ -59,7 +59,6 @@ impl Message {
         match self {
             Self::Text(x) => serde_json::from_str(x).map_err(Error::decode),
             Self::Binary(x) => serde_json::from_slice(x).map_err(Error::decode),
-            #[allow(deprecated)]
             Self::Ping(_) | Self::Pong(_) | Self::Close { .. } => Err(Error::decode(
                 serde_json::Error::custom("neither text nor binary"),
             )),

--- a/src/core/body/incoming.rs
+++ b/src/core/body/incoming.rs
@@ -115,7 +115,6 @@ impl Incoming {
         Incoming { kind }
     }
 
-    #[allow(dead_code)]
     pub(crate) fn empty() -> Incoming {
         Incoming::new(Kind::Empty)
     }

--- a/src/core/client/connect/http.rs
+++ b/src/core/client/connect/http.rs
@@ -514,7 +514,6 @@ pin_project! {
     // so that users don't rely on it fitting in a `Pin<Box<dyn Future>>` slot
     // (and thus we can change the type in the future).
     #[must_use = "futures do nothing unless polled"]
-    #[allow(missing_debug_implementations)]
     pub struct HttpConnecting<R> {
         #[pin]
         fut: BoxConnecting,

--- a/src/core/client/connect/proxy/socks.rs
+++ b/src/core/client/connect/proxy/socks.rs
@@ -90,7 +90,6 @@ pin_project! {
     // so that users don't rely on it fitting in a `Pin<Box<dyn Future>>` slot
     // (and thus we can change the type in the future).
     #[must_use = "futures do nothing unless polled"]
-    #[allow(missing_debug_implementations)]
     pub struct Handshaking<F, T, E> {
         #[pin]
         fut: BoxHandshaking<T, E>,

--- a/src/core/client/connect/proxy/tunnel.rs
+++ b/src/core/client/connect/proxy/tunnel.rs
@@ -51,7 +51,6 @@ pin_project! {
     // so that users don't rely on it fitting in a `Pin<Box<dyn Future>>` slot
     // (and thus we can change the type in the future).
     #[must_use = "futures do nothing unless polled"]
-    #[allow(missing_debug_implementations)]
     pub struct Tunneling<F, T> {
         #[pin]
         fut: BoxTunneling<T>,

--- a/src/core/client/mod.rs
+++ b/src/core/client/mod.rs
@@ -885,8 +885,6 @@ impl Future for ResponseFuture {
 
 // ===== impl PoolClient =====
 
-// FIXME: allow() required due to `impl Trait` leaking types to this lint
-#[allow(missing_debug_implementations)]
 struct PoolClient<B> {
     conn_info: Connected,
     tx: PoolTx<B>,
@@ -899,10 +897,7 @@ enum PoolTx<B> {
 }
 
 impl<B> PoolClient<B> {
-    fn poll_ready(
-        &mut self,
-        #[allow(unused_variables)] cx: &mut task::Context<'_>,
-    ) -> Poll<Result<(), Error>> {
+    fn poll_ready(&mut self, cx: &mut task::Context<'_>) -> Poll<Result<(), Error>> {
         match self.tx {
             PoolTx::Http1(ref mut tx) => tx.poll_ready(cx).map_err(Error::closed),
 

--- a/src/core/client/pool.rs
+++ b/src/core/client/pool.rs
@@ -28,8 +28,6 @@ use crate::{
     sync::Mutex,
 };
 
-// FIXME: allow() required due to `impl Trait` leaking types to this lint
-#[allow(missing_debug_implementations)]
 pub struct Pool<T, K: Key> {
     // If the pool is disabled, this is None.
     inner: Option<Arc<Mutex<PoolInner<T, K>>>>,
@@ -561,8 +559,6 @@ struct Idle<T> {
     value: T,
 }
 
-// FIXME: allow() required due to `impl Trait` leaking types to this lint
-#[allow(missing_debug_implementations)]
 pub struct Checkout<T, K: Key> {
     key: K,
     pool: Pool<T, K>,
@@ -706,8 +702,6 @@ impl<T, K: Key> Drop for Checkout<T, K> {
     }
 }
 
-// FIXME: allow() required due to `impl Trait` leaking types to this lint
-#[allow(missing_debug_implementations)]
 pub struct Connecting<T: Poolable, K: Key> {
     key: K,
     pool: WeakOpt<Mutex<PoolInner<T, K>>>,

--- a/src/core/common/lazy.rs
+++ b/src/core/common/lazy.rs
@@ -22,7 +22,6 @@ where
 
 // FIXME: allow() required due to `impl Trait` leaking types to this lint
 pin_project! {
-    #[allow(missing_debug_implementations)]
     pub(crate) struct Lazy<F, R> {
         #[pin]
         inner: Inner<F, R>,

--- a/src/core/proto/h1/conn.rs
+++ b/src/core/proto/h1/conn.rs
@@ -17,7 +17,7 @@ use super::{
     Decoder, Encode, EncodedBuf, Encoder, Http1Transaction, ParseContext, Wants, io::Buffered,
 };
 use crate::core::{
-    Error,
+    Error, Result,
     body::DecodedLength,
     proto::{BodyLength, MessageHead, headers},
     rt::{Read, Write},
@@ -151,7 +151,7 @@ where
     pub(super) fn poll_read_head(
         &mut self,
         cx: &mut Context<'_>,
-    ) -> Poll<Option<crate::core::Result<(MessageHead<T::Incoming>, DecodedLength, Wants)>>> {
+    ) -> Poll<Option<Result<(MessageHead<T::Incoming>, DecodedLength, Wants)>>> {
         debug_assert!(self.can_read_head());
         trace!("Conn::read_head");
 


### PR DESCRIPTION
#[allow]` macros