### PR TITLE
refactor(client): allow `?Sized` trait objects in `dns_resolver`

### DIFF
--- a/src/client/http/mod.rs
+++ b/src/client/http/mod.rs
@@ -1246,11 +1246,8 @@ impl ClientBuilder {
     /// Overrides for specific names passed to `resolve` and `resolve_to_addrs` will
     /// still be applied on top of this resolver.
     #[inline]
-    pub fn dns_resolver<R>(mut self, resolver: R) -> ClientBuilder
-    where
-        R: Into<Arc<dyn Resolve + 'static>>,
-    {
-        self.config.dns_resolver = Some(resolver.into());
+    pub fn dns_resolver(mut self, resolver: Arc<dyn Resolve>) -> ClientBuilder {
+        self.config.dns_resolver = Some(resolver);
         self
     }
 


### PR DESCRIPTION
This allows `?Sized` type

```rust
use std::{
    future::ready,
    net::{IpAddr, Ipv4Addr, SocketAddr},
    sync::{Arc, Mutex},
};

use wreq::{
    ClientBuilder,
    dns::{Name, Resolve, Resolving},
};

#[derive(Clone, Debug)]
pub struct TestDnsResolver {
    port: u16,
}

impl TestDnsResolver {
    pub fn new(port: u16) -> Self {
        Self { port }
    }
}

impl Resolve for TestDnsResolver {
    fn resolve(&self, _name: Name) -> Resolving {
        let addr_list =
            Box::new([SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), self.port)].into_iter());
        Box::pin(ready(Ok(addr_list as _)))
    }
}

static DNS_OVERRIDE: Mutex<Option<Arc<dyn Resolve>>> = Mutex::new(None);

fn main() -> Result<(), Box<dyn std::error::Error>> {
    *DNS_OVERRIDE.lock().unwrap() = Some(Arc::new(TestDnsResolver::new(16384)));

    let mut client_builder = ClientBuilder::new();

    if let Some(ref resolver) = *DNS_OVERRIDE.lock().unwrap() {
        client_builder = client_builder.dns_resolver(resolver.clone());
        client_builder = client_builder.dns_resolver(Arc::new(TestDnsResolver::new(16384)));
    }

    let _client = client_builder.build();

    Ok(())
}

```