### PR TITLE
fix(deps): upgrade url to v2.5.4 to address CVE-2024-12224

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ tracing = ["http2/tracing", "dep:tracing"]
 
 [dependencies]
 base64 = "0.22"
-url = "2.5"
+url = "2.5.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_urlencoded = "0.7.1"
 percent-encoding = "2.3.1"
@@ -93,7 +93,7 @@ schnellru = { version = "0.2.4", default-features = false }
 ahash = { version = "0.8.12", default-features = false }
 
 ## runtime
-tokio = { version = "1.47.0", default-features = false, features = [
+tokio = { version = "1.47.1", default-features = false, features = [
     "net",
     "time",
     "rt",
@@ -132,7 +132,7 @@ cookie_store = { version = "0.22", optional = true }
 tower-http = { version = "0.6.6", default-features = false, optional = true }
 
 ## tokio util
-tokio-util = { version = "0.7.15", default-features = false, optional = true }
+tokio-util = { version = "0.7.16", default-features = false, optional = true }
 
 ## socks
 tokio-socks = { version = "0.5.2", optional = true }

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,7 +6,7 @@ use crate::{StatusCode, Url, core::ext::ReasonPhrase, util::Escape};
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// A boxed error type that can be used for dynamic error handling.
-pub(crate) type BoxError = Box<dyn StdError + Send + Sync>;
+pub type BoxError = Box<dyn StdError + Send + Sync>;
 
 /// The Errors that may occur when processing a `Request`.
 ///


### PR DESCRIPTION
fix(deps): upgrade url to v2.5.4 (CVE-2024-12224)

Addresses security vulnerability in URL parsing
Ref: GHSA-h97m-ww89-6jmq