### PR TITLE
refactor(client): remove `no_keepalive` method

### DIFF
--- a/src/client/http/mod.rs
+++ b/src/client/http/mod.rs
@@ -840,14 +840,6 @@ impl ClientBuilder {
         self
     }
 
-    /// Disable keep-alive for the client.
-    #[inline]
-    pub fn no_keepalive(mut self) -> ClientBuilder {
-        self.config.pool_max_idle_per_host = 0;
-        self.config.tcp_keepalive = None;
-        self
-    }
-
     /// Restrict the Client to be used with HTTPS only requests.
     ///
     /// Defaults to false.


### PR DESCRIPTION
This was a legacy option for disabling the connection pool, which could be confusing. The connection pool can still be disabled by setting pool_max_idle_per_host to 0.