### PR TITLE
refactor(connect): safely convert `socket2::Socket` to Tokio `TcpSocket`

### DIFF
--- a/src/core/client/connect/http.rs
+++ b/src/core/client/connect/http.rs
@@ -951,25 +951,8 @@ fn connect(
     )
     .map_err(ConnectError::m("tcp bind local error"))?;
 
-    #[cfg(unix)]
-    let socket = unsafe {
-        // Safety: `from_raw_fd` is only safe to call if ownership of the raw
-        // file descriptor is transferred. Since we call `into_raw_fd` on the
-        // socket2 socket, it gives up ownership of the fd and will not close
-        // it, so this is safe.
-        use std::os::unix::io::{FromRawFd, IntoRawFd};
-        TcpSocket::from_raw_fd(socket.into_raw_fd())
-    };
-
-    #[cfg(windows)]
-    let socket = unsafe {
-        // Safety: `from_raw_socket` is only safe to call if ownership of the raw
-        // Windows SOCKET is transferred. Since we call `into_raw_socket` on the
-        // socket2 socket, it gives up ownership of the SOCKET and will not close
-        // it, so this is safe.
-        use std::os::windows::io::{FromRawSocket, IntoRawSocket};
-        TcpSocket::from_raw_socket(socket.into_raw_socket())
-    };
+    // Safely convert socket2::Socket to tokio TcpSocket.
+    let socket = TcpSocket::from_std_stream(socket.into());
 
     if config.reuse_address {
         if let Err(_e) = socket.set_reuseaddr(true) {


### PR DESCRIPTION
from: https://docs.rs/tokio/latest/tokio/net/struct.TcpSocket.html#method.from_std_stream