### PR TITLE
chore(deps): replace `base64` with `boring2::base64`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,6 @@ system-proxy = ["dep:system-configuration", "dep:windows-registry"]
 tracing = ["http2/tracing", "dep:tracing"]
 
 [dependencies]
-base64 = "0.22"
 url = "2.5.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_urlencoded = "0.7.1"


### PR DESCRIPTION
On my machine, the boring2 base64 encoding implementation benchmarks faster than Rust’s base64. Replacing the implementation also reduces crate dependencies, which shortens compile time.