### PR TITLE
feat(tls): allow custom ALPN/ALPS configuration

### DIFF
--- a/src/tls/conn/mod.rs
+++ b/src/tls/conn/mod.rs
@@ -224,7 +224,7 @@ impl Inner {
         // Set ALPS protos
         if let Some(ref alps_values) = self.config.alps_protocols {
             for alps in alps_values.iter() {
-                cfg.add_application_settings(alps.value())?;
+                cfg.add_application_settings(alps.0)?;
             }
 
             // By default, the old endpoint is used.

--- a/src/tls/mod.rs
+++ b/src/tls/mod.rs
@@ -36,7 +36,7 @@ use bytes::{BufMut, Bytes, BytesMut};
 
 /// A TLS protocol version.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
-pub struct TlsVersion(pub(super) ssl::SslVersion);
+pub struct TlsVersion(ssl::SslVersion);
 
 impl TlsVersion {
     /// Version 1.0 of the TLS protocol.
@@ -66,13 +66,18 @@ impl AlpnProtocol {
     /// Prefer HTTP/3
     pub const HTTP3: AlpnProtocol = AlpnProtocol(b"h3");
 
+    /// Create a new [`AlpsProtocol`] from a static byte slice.
     #[inline]
-    pub(crate) fn encode(self) -> Bytes {
-        Self::encode_sequence(std::iter::once(&self))
+    pub const fn new(value: &'static [u8]) -> Self {
+        AlpnProtocol(value)
     }
 
     #[inline]
-    pub(crate) fn encode_sequence<'a, I>(items: I) -> Bytes
+    fn encode(self) -> Bytes {
+        Self::encode_sequence(std::iter::once(&self))
+    }
+
+    fn encode_sequence<'a, I>(items: I) -> Bytes
     where
         I: IntoIterator<Item = &'a AlpnProtocol>,
     {
@@ -99,9 +104,10 @@ impl AlpsProtocol {
     /// Prefer HTTP/3
     pub const HTTP3: AlpsProtocol = AlpsProtocol(b"h3");
 
+    /// Create a new [`AlpsProtocol`] from a static byte slice.
     #[inline]
-    pub(crate) const fn value(self) -> &'static [u8] {
-        self.0
+    pub const fn new(value: &'static [u8]) -> Self {
+        AlpsProtocol(value)
     }
 }
 

--- a/src/tls/mod.rs
+++ b/src/tls/mod.rs
@@ -66,7 +66,7 @@ impl AlpnProtocol {
     /// Prefer HTTP/3
     pub const HTTP3: AlpnProtocol = AlpnProtocol(b"h3");
 
-    /// Create a new [`AlpsProtocol`] from a static byte slice.
+    /// Create a new [`AlpnProtocol`] from a static byte slice.
     #[inline]
     pub const fn new(value: &'static [u8]) -> Self {
         AlpnProtocol(value)
@@ -103,12 +103,6 @@ impl AlpsProtocol {
 
     /// Prefer HTTP/3
     pub const HTTP3: AlpsProtocol = AlpsProtocol(b"h3");
-
-    /// Create a new [`AlpsProtocol`] from a static byte slice.
-    #[inline]
-    pub const fn new(value: &'static [u8]) -> Self {
-        AlpsProtocol(value)
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This allows defining older ALPN protocol types: h2, h2-16, h2-15, h2-14, spdy/3.1, spdy/3, http/1.1. As for ALPS, I’m not sure if it’s available. In addition, if the negotiated version is an older HTTP protocol, requests may fail. However, at least this enables mimicking TLS handshakes from older devices, such as Safari 12.1.1 / iOS 12.3.1.