### PR TITLE
fix(client): allow absolute-form if is_proxied is set even on HTTPS

### DIFF
--- a/src/core/client/service/util.rs
+++ b/src/core/client/service/util.rs
@@ -26,12 +26,6 @@ pub(super) fn absolute_form(uri: &mut Uri) {
         uri.authority().is_some(),
         "absolute_form needs an authority"
     );
-    // If the URI is to HTTPS, and the connector claimed to be a proxy,
-    // then it *should* have tunneled, and so we don't want to send
-    // absolute-form in that case.
-    if uri.scheme() == Some(&Scheme::HTTPS) {
-        origin_form(uri);
-    }
 }
 
 pub(super) fn authority_form(uri: &mut Uri) {


### PR DESCRIPTION
from: https://github.com/hyperium/hyper-util/commit/9fb7cd569ce6cc53b9aae150824a6f49af7e01db