### PR TITLE
refactor(redirect): refactor handling of redirect history

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ tower = { version = "0.5.2", default-features = false, features = [
 ] }
 bytes = "1.10.1"
 http = "1.3.1"
-http2 = { version = "0.5.7", features = ["unstable"] }
+http2 = { version = "0.5.9", features = ["unstable"] }
 httparse = "1.10.1"
 http-body = "1.0.1"
 http-body-util = "0.1.3"

--- a/examples/request_with_redirect.rs
+++ b/examples/request_with_redirect.rs
@@ -8,9 +8,7 @@ async fn main() -> wreq::Result<()> {
             // we can inspect the redirect attempt
             println!(
                 "Redirecting (status: {}) to {:?} and headers: {:#?}",
-                attempt.status(),
-                attempt.uri(),
-                attempt.headers()
+                attempt.status, attempt.uri, attempt.headers
             );
 
             // we can follow redirects as normal

--- a/src/client/http.rs
+++ b/src/client/http.rs
@@ -220,7 +220,6 @@ struct Config {
     auto_sys_proxy: bool,
     retry_policy: retry::Policy,
     redirect_policy: redirect::Policy,
-    redirect_history: bool,
     referer: bool,
     timeout_options: TimeoutOptions,
     #[cfg(feature = "cookies")]
@@ -302,7 +301,6 @@ impl Client {
                 auto_sys_proxy: true,
                 retry_policy: retry::Policy::default(),
                 redirect_policy: redirect::Policy::none(),
-                redirect_history: false,
                 referer: true,
                 timeout_options: TimeoutOptions::default(),
                 #[cfg(feature = "hickory-dns")]
@@ -603,8 +601,7 @@ impl ClientBuilder {
                 .layer({
                     let policy = FollowRedirectPolicy::new(config.redirect_policy)
                         .with_referer(config.referer)
-                        .with_https_only(config.https_only)
-                        .with_history(config.redirect_history);
+                        .with_https_only(config.https_only);
                     FollowRedirectLayer::with_policy(policy)
                 })
                 .layer(ResponseBodyTimeoutLayer::new(config.timeout_options))
@@ -942,15 +939,6 @@ impl ClientBuilder {
     #[inline]
     pub fn redirect(mut self, policy: redirect::Policy) -> ClientBuilder {
         self.config.redirect_policy = policy;
-        self
-    }
-
-    /// Enable or disable redirect history tracking.
-    ///
-    /// Default is `false`.
-    #[inline]
-    pub fn history(mut self, enable: bool) -> ClientBuilder {
-        self.config.redirect_history = enable;
         self
     }
 

--- a/src/client/layer/redirect.rs
+++ b/src/client/layer/redirect.rs
@@ -1,109 +1,17 @@
 //! Middleware for following redirections.
 
 mod future;
-pub mod policy;
+mod layer;
+mod policy;
 
-use std::{
-    mem,
-    task::{Context, Poll},
-};
+use std::mem;
 
-use futures_util::future::Either;
-use http::{Request, Response};
 use http_body::Body;
-use tower::{Layer, Service};
 
-use self::{future::ResponseFuture, policy::Policy};
-use crate::error::BoxError;
-
-/// [`Layer`] for retrying requests with a [`Service`] to follow redirection responses.
-#[derive(Clone, Copy, Default)]
-pub struct FollowRedirectLayer<P> {
-    policy: P,
-}
-
-impl<P> FollowRedirectLayer<P> {
-    /// Create a new [`FollowRedirectLayer`] with the given redirection [`Policy`].
-    #[inline(always)]
-    pub const fn with_policy(policy: P) -> Self {
-        FollowRedirectLayer { policy }
-    }
-}
-
-impl<S, P> Layer<S> for FollowRedirectLayer<P>
-where
-    S: Clone,
-    P: Clone,
-{
-    type Service = FollowRedirect<S, P>;
-
-    #[inline(always)]
-    fn layer(&self, inner: S) -> Self::Service {
-        FollowRedirect::with_policy(inner, self.policy.clone())
-    }
-}
-
-/// Middleware that retries requests with a [`Service`] to follow redirection responses.
-#[derive(Clone, Copy)]
-pub struct FollowRedirect<S, P> {
-    inner: S,
-    policy: P,
-}
-
-impl<S, P> FollowRedirect<S, P>
-where
-    P: Clone,
-{
-    /// Create a new [`FollowRedirect`] with the given redirection [`Policy`].
-    #[inline(always)]
-    pub const fn with_policy(inner: S, policy: P) -> Self {
-        FollowRedirect { inner, policy }
-    }
-}
-
-impl<ReqBody, ResBody, S, P> Service<Request<ReqBody>> for FollowRedirect<S, P>
-where
-    S: Service<Request<ReqBody>, Response = Response<ResBody>> + Clone,
-    S::Error: From<BoxError>,
-    P: Policy<ReqBody, S::Error> + Clone,
-    ReqBody: Body + Default,
-{
-    type Response = Response<ResBody>;
-    type Error = S::Error;
-    type Future = ResponseFuture<S, ReqBody, P>;
-
-    #[inline(always)]
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner.poll_ready(cx)
-    }
-
-    fn call(&mut self, mut req: Request<ReqBody>) -> Self::Future {
-        let service = self.inner.clone();
-        let mut service = mem::replace(&mut self.inner, service);
-        let mut policy = self.policy.clone();
-        policy.on_extensions(req.extensions());
-
-        if policy.allowed() {
-            let mut clone_body = BodyRepr::None;
-            clone_body.try_clone_from(req.body(), &policy);
-            policy.on_request(&mut req);
-
-            let (parts, body) = req.into_parts();
-            ResponseFuture::Redirect {
-                future: Either::Left(service.call(Request::from_parts(parts.clone(), body))),
-                pending_future: None,
-                service,
-                policy,
-                parts,
-                body: clone_body,
-            }
-        } else {
-            ResponseFuture::Direct {
-                future: service.call(req),
-            }
-        }
-    }
-}
+pub use self::{
+    layer::{FollowRedirect, FollowRedirectLayer},
+    policy::{Action, Attempt, Policy},
+};
 
 enum BodyRepr<B> {
     Some(B),

--- a/src/client/layer/redirect/layer.rs
+++ b/src/client/layer/redirect/layer.rs
@@ -1,0 +1,101 @@
+use std::{
+    mem,
+    task::{Context, Poll},
+};
+
+use futures_util::future::Either;
+use http::{Request, Response};
+use http_body::Body;
+use tower::{Layer, Service};
+
+use super::{BodyRepr, future::ResponseFuture, policy::Policy};
+use crate::error::BoxError;
+
+/// [`Layer`] for retrying requests with a [`Service`] to follow redirection responses.
+#[derive(Clone, Copy, Default)]
+pub struct FollowRedirectLayer<P> {
+    policy: P,
+}
+
+impl<P> FollowRedirectLayer<P> {
+    /// Create a new [`FollowRedirectLayer`] with the given redirection [`Policy`].
+    #[inline(always)]
+    pub const fn with_policy(policy: P) -> Self {
+        FollowRedirectLayer { policy }
+    }
+}
+
+impl<S, P> Layer<S> for FollowRedirectLayer<P>
+where
+    S: Clone,
+    P: Clone,
+{
+    type Service = FollowRedirect<S, P>;
+
+    #[inline(always)]
+    fn layer(&self, inner: S) -> Self::Service {
+        FollowRedirect::with_policy(inner, self.policy.clone())
+    }
+}
+
+/// Middleware that retries requests with a [`Service`] to follow redirection responses.
+#[derive(Clone, Copy)]
+pub struct FollowRedirect<S, P> {
+    inner: S,
+    policy: P,
+}
+
+impl<S, P> FollowRedirect<S, P>
+where
+    P: Clone,
+{
+    /// Create a new [`FollowRedirect`] with the given redirection [`Policy`].
+    #[inline(always)]
+    pub const fn with_policy(inner: S, policy: P) -> Self {
+        FollowRedirect { inner, policy }
+    }
+}
+
+impl<ReqBody, ResBody, S, P> Service<Request<ReqBody>> for FollowRedirect<S, P>
+where
+    S: Service<Request<ReqBody>, Response = Response<ResBody>> + Clone,
+    S::Error: From<BoxError>,
+    P: Policy<ReqBody, S::Error> + Clone,
+    ReqBody: Body + Default,
+{
+    type Response = Response<ResBody>;
+    type Error = S::Error;
+    type Future = ResponseFuture<S, ReqBody, P>;
+
+    #[inline]
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: Request<ReqBody>) -> Self::Future {
+        let service = self.inner.clone();
+        let mut service = mem::replace(&mut self.inner, service);
+        let mut policy = self.policy.clone();
+
+        if policy.follow_redirects(req.extensions()) {
+            let mut body_repr = BodyRepr::None;
+            body_repr.try_clone_from(req.body(), &policy);
+            policy.on_request(&mut req);
+
+            let (parts, body) = req.into_parts();
+            let req = Request::from_parts(parts.clone(), body);
+            ResponseFuture::Redirect {
+                future: Either::Left(service.call(req)),
+                pending_future: None,
+                service,
+                policy,
+                parts,
+                body_repr,
+            }
+        } else {
+            ResponseFuture::Direct {
+                future: service.call(req),
+            }
+        }
+    }
+}

--- a/src/client/request.rs
+++ b/src/client/request.rs
@@ -804,8 +804,8 @@ where
             method,
             uri,
             headers,
-            body: Some(body.into()),
             extensions,
+            body: Some(body.into()),
         }
     }
 }

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -8,13 +8,13 @@ use std::{borrow::Cow, error::Error as StdError, fmt, sync::Arc};
 
 use bytes::Bytes;
 use futures_util::FutureExt;
-use http::{Extensions, HeaderMap, HeaderValue, StatusCode, Uri, uri::Authority};
+use http::{Extensions, HeaderMap, HeaderValue, StatusCode, Uri};
 
 use crate::{
     client::{
         Body,
         ext::RequestConfig,
-        layer::{config::RequestRedirectPolicy, redirect::policy},
+        layer::{config::RequestRedirectPolicy, redirect},
     },
     error::{BoxError, Error},
     ext::UriExt,
@@ -38,26 +38,43 @@ pub struct Policy {
 /// A type that holds information on the next request and previous requests
 /// in redirect chain.
 #[derive(Debug)]
+#[non_exhaustive]
 pub struct Attempt<'a, const PENDING: bool = true> {
-    status: StatusCode,
-    headers: Cow<'a, HeaderMap>,
-    next: Cow<'a, Uri>,
-    previous: Cow<'a, [Uri]>,
+    /// The status code of the redirect response.
+    pub status: StatusCode,
+
+    /// The headers of the redirect response.
+    pub headers: Cow<'a, HeaderMap>,
+
+    /// The next URI to redirect to.
+    pub uri: Cow<'a, Uri>,
+
+    /// The previous URIs that have already been requested in this chain.
+    pub previous: Cow<'a, [Uri]>,
 }
 
 /// An action to perform when a redirect status code is found.
 #[derive(Debug)]
 pub struct Action {
-    inner: policy::Action,
+    inner: redirect::Action,
 }
+
+/// Redirect history information for a response.
+#[derive(Debug, Clone)]
+pub struct History(Vec<HistoryEntry>);
 
 /// An entry in the redirect history.
 #[derive(Debug, Clone)]
-pub struct History {
-    status: StatusCode,
-    uri: Uri,
-    previous: Uri,
-    headers: HeaderMap,
+#[non_exhaustive]
+pub struct HistoryEntry {
+    /// The status code of the redirect response.
+    pub status: StatusCode,
+    /// The URI of the redirect response.
+    pub uri: Uri,
+    /// The previous URI before the redirect response.
+    pub previous: Uri,
+    /// The headers of the redirect response.
+    pub headers: HeaderMap,
 }
 
 #[derive(Clone)]
@@ -86,7 +103,7 @@ pub(crate) struct FollowRedirectPolicy {
     referer: bool,
     uris: Vec<Uri>,
     https_only: bool,
-    history: Option<Vec<History>>,
+    history: Option<Vec<HistoryEntry>>,
 }
 
 // ===== impl Policy =====
@@ -131,9 +148,9 @@ impl Policy {
     /// #
     /// # fn run() -> Result<(), Error> {
     /// let custom = redirect::Policy::custom(|attempt| {
-    ///     if attempt.previous().len() > 5 {
+    ///     if attempt.previous.len() > 5 {
     ///         attempt.error("too many redirects")
-    ///     } else if attempt.uri() == "example.domain" {
+    ///     } else if attempt.uri.host() == Some("example.domain") {
     ///         // prevent redirects to 'example.domain'
     ///         attempt.stop()
     ///     } else {
@@ -197,11 +214,11 @@ impl Policy {
         headers: &HeaderMap,
         next: &Uri,
         previous: &[Uri],
-    ) -> policy::Action {
+    ) -> redirect::Action {
         self.redirect(Attempt {
             status,
             headers: Cow::Borrowed(headers),
-            next: Cow::Borrowed(next),
+            uri: Cow::Borrowed(next),
             previous: Cow::Borrowed(previous),
         })
         .inner
@@ -219,35 +236,11 @@ impl Default for Policy {
 // ===== impl Attempt =====
 
 impl<'a, const PENDING: bool> Attempt<'a, PENDING> {
-    /// Get the type of redirect.
-    #[inline]
-    pub fn status(&self) -> StatusCode {
-        self.status
-    }
-
-    /// Get the headers of redirect.
-    #[inline]
-    pub fn headers(&self) -> &HeaderMap {
-        self.headers.as_ref()
-    }
-
-    /// Get the next URI to redirect to.
-    #[inline]
-    pub fn uri(&self) -> &Uri {
-        self.next.as_ref()
-    }
-
-    /// Get the list of previous URIs that have already been requested in this chain.
-    #[inline]
-    pub fn previous(&self) -> &[Uri] {
-        self.previous.as_ref()
-    }
-
     /// Returns an action meaning wreq should follow the next URI.
     #[inline]
     pub fn follow(self) -> Action {
         Action {
-            inner: policy::Action::Follow,
+            inner: redirect::Action::Follow,
         }
     }
 
@@ -257,7 +250,7 @@ impl<'a, const PENDING: bool> Attempt<'a, PENDING> {
     #[inline]
     pub fn stop(self) -> Action {
         Action {
-            inner: policy::Action::Stop,
+            inner: redirect::Action::Stop,
         }
     }
 
@@ -267,7 +260,7 @@ impl<'a, const PENDING: bool> Attempt<'a, PENDING> {
     #[inline]
     pub fn error<E: Into<BoxError>>(self, error: E) -> Action {
         Action {
-            inner: policy::Action::Error(error.into()),
+            inner: redirect::Action::Error(error.into()),
         }
     }
 }
@@ -286,7 +279,7 @@ impl<'a> Attempt<'a, true> {
     /// let policy = redirect::Policy::custom(|attempt| {
     ///     attempt.pending(|attempt| async move {
     ///         // Perform some async operation
-    ///         if attempt.uri().host() == Some("trusted.domain") {
+    ///         if attempt.uri.host() == Some("trusted.domain") {
     ///             attempt.follow()
     ///         } else {
     ///             attempt.stop()
@@ -301,53 +294,36 @@ impl<'a> Attempt<'a, true> {
     {
         let attempt = Attempt {
             status: self.status,
-            headers: Cow::Owned(self.headers().clone()),
-            next: Cow::Owned(self.uri().clone()),
-            previous: Cow::Owned(self.previous().to_vec()),
+            headers: Cow::Owned(self.headers.into_owned()),
+            uri: Cow::Owned(self.uri.into_owned()),
+            previous: Cow::Owned(self.previous.into_owned()),
         };
         let pending = Box::pin(task(attempt).map(|action| action.inner));
         Action {
-            inner: policy::Action::Pending(pending),
+            inner: redirect::Action::Pending(pending),
         }
     }
 }
 
 // ===== impl History =====
 
-impl History {
-    /// Get the status code of the redirect response.
-    #[inline]
-    pub fn status(&self) -> StatusCode {
-        self.status
-    }
+impl IntoIterator for History {
+    type Item = HistoryEntry;
+    type IntoIter = std::vec::IntoIter<HistoryEntry>;
 
-    /// Get the URI of the redirect response.
     #[inline]
-    pub fn uri(&self) -> &Uri {
-        &self.uri
-    }
-
-    /// Get the previous URI before the redirect response.
-    #[inline]
-    pub fn previous(&self) -> &Uri {
-        &self.previous
-    }
-
-    /// Get the headers of the redirect response.
-    #[inline]
-    pub fn headers(&self) -> &HeaderMap {
-        &self.headers
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
     }
 }
 
-impl From<policy::Attempt<'_>> for History {
-    fn from(attempt: policy::Attempt<'_>) -> Self {
-        Self {
-            status: attempt.status,
-            uri: attempt.location.clone(),
-            previous: attempt.previous.clone(),
-            headers: attempt.headers.clone(),
-        }
+impl<'a> IntoIterator for &'a History {
+    type Item = &'a HistoryEntry;
+    type IntoIter = std::slice::Iter<'a, HistoryEntry>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
     }
 }
 
@@ -400,17 +376,10 @@ impl FollowRedirectPolicy {
         self.https_only = https_only;
         self
     }
-
-    /// Enables or disables redirect history tracking.
-    #[inline]
-    pub fn with_history(mut self, history: bool) -> Self {
-        self.history = history.then_some(Vec::new());
-        self
-    }
 }
 
-impl policy::Policy<Body, BoxError> for FollowRedirectPolicy {
-    fn redirect(&mut self, attempt: policy::Attempt<'_>) -> Result<policy::Action, BoxError> {
+impl redirect::Policy<Body, BoxError> for FollowRedirectPolicy {
+    fn redirect(&mut self, attempt: redirect::Attempt<'_>) -> Result<redirect::Action, BoxError> {
         // Parse the next URI from the attempt.
         let previous_uri = attempt.previous;
         let next_uri = attempt.location;
@@ -426,7 +395,7 @@ impl policy::Policy<Body, BoxError> for FollowRedirectPolicy {
 
         // Check if the next URI is already in the list of URLs.
         match policy.check(attempt.status, attempt.headers, next_uri, &self.uris) {
-            policy::Action::Follow => {
+            redirect::Action::Follow => {
                 // Validate the redirect URI scheme
                 if !(next_uri.is_http() || next_uri.is_https()) {
                     return Err(Error::uri_bad_scheme(next_uri.clone()).into());
@@ -441,16 +410,21 @@ impl policy::Policy<Body, BoxError> for FollowRedirectPolicy {
                     .into());
                 }
 
-                // Record history if enabled
-                if let Some(history) = self.history.as_mut() {
-                    history.push(History::from(attempt));
+                // Record redirect history
+                if !matches!(policy.inner, PolicyKind::None) {
+                    self.history.get_or_insert_default().push(HistoryEntry {
+                        status: attempt.status,
+                        uri: attempt.location.clone(),
+                        previous: attempt.previous.clone(),
+                        headers: attempt.headers.clone(),
+                    });
                 }
 
-                Ok(policy::Action::Follow)
+                Ok(redirect::Action::Follow)
             }
-            policy::Action::Stop => Ok(policy::Action::Stop),
-            policy::Action::Pending(task) => Ok(policy::Action::Pending(task)),
-            policy::Action::Error(err) => Err(Error::redirect(err, previous_uri.clone()).into()),
+            redirect::Action::Stop => Ok(redirect::Action::Stop),
+            redirect::Action::Pending(task) => Ok(redirect::Action::Pending(task)),
+            redirect::Action::Error(err) => Err(Error::redirect(err, previous_uri.clone()).into()),
         }
     }
 
@@ -459,7 +433,7 @@ impl policy::Policy<Body, BoxError> for FollowRedirectPolicy {
         remove_sensitive_headers(req.headers_mut(), &next_url, &self.uris);
         if self.referer {
             if let Some(previous_url) = self.uris.last() {
-                if let Some(v) = make_referer(&next_url, previous_url) {
+                if let Some(v) = make_referer(next_url, previous_url) {
                     req.headers_mut().insert(REFERER, v);
                 }
             }
@@ -468,17 +442,12 @@ impl policy::Policy<Body, BoxError> for FollowRedirectPolicy {
 
     fn on_response<Body>(&mut self, response: &mut http::Response<Body>) {
         if let Some(history) = self.history.take() {
-            response.extensions_mut().insert(history);
+            response.extensions_mut().insert(History(history));
         }
     }
 
-    #[inline]
-    fn on_extensions(&mut self, extensions: &Extensions) {
+    fn follow_redirects(&mut self, extensions: &Extensions) -> bool {
         self.policy.load(extensions);
-    }
-
-    #[inline]
-    fn allowed(&self) -> bool {
         self.policy
             .as_ref()
             .is_some_and(|policy| !matches!(policy.inner, PolicyKind::None))
@@ -490,25 +459,13 @@ impl policy::Policy<Body, BoxError> for FollowRedirectPolicy {
     }
 }
 
-fn make_referer(next: &Uri, previous: &Uri) -> Option<HeaderValue> {
+fn make_referer(next: Uri, previous: &Uri) -> Option<HeaderValue> {
     if next.is_http() && previous.is_https() {
         return None;
     }
 
-    let referer = {
-        let mut parts = previous.clone().into_parts();
-        if let Some(authority) = &mut parts.authority {
-            let host = authority.host();
-            parts.authority = match authority.port() {
-                Some(port) => {
-                    Authority::from_maybe_shared(Bytes::from(format!("{host}:{port}"))).ok()
-                }
-                None => host.parse().ok(),
-            };
-        }
-        Uri::from_parts(parts).ok()?
-    };
-
+    let mut referer = previous.clone();
+    referer.set_userinfo("", None);
     HeaderValue::from_maybe_shared(Bytes::from(referer.to_string())).ok()
 }
 
@@ -540,14 +497,14 @@ mod tests {
             .collect::<Vec<_>>();
 
         match policy.check(StatusCode::FOUND, &HeaderMap::new(), &next, &previous) {
-            policy::Action::Follow => (),
+            redirect::Action::Follow => (),
             other => panic!("unexpected {other:?}"),
         }
 
         previous.push(Uri::try_from("http://a.b.d/e/33").unwrap());
 
         match policy.check(StatusCode::FOUND, &HeaderMap::new(), &next, &previous) {
-            policy::Action::Error(err) if err.is::<TooManyRedirects>() => (),
+            redirect::Action::Error(err) if err.is::<TooManyRedirects>() => (),
             other => panic!("unexpected {other:?}"),
         }
     }
@@ -559,7 +516,7 @@ mod tests {
         let previous = vec![Uri::try_from("http://a.b/c").unwrap()];
 
         match policy.check(StatusCode::FOUND, &HeaderMap::new(), &next, &previous) {
-            policy::Action::Error(err) if err.is::<TooManyRedirects>() => (),
+            redirect::Action::Error(err) if err.is::<TooManyRedirects>() => (),
             other => panic!("unexpected {other:?}"),
         }
     }
@@ -567,7 +524,7 @@ mod tests {
     #[test]
     fn test_redirect_policy_custom() {
         let policy = Policy::custom(|attempt| {
-            if attempt.uri().host() == Some("foo") {
+            if attempt.uri.host() == Some("foo") {
                 attempt.stop()
             } else {
                 attempt.follow()
@@ -576,13 +533,13 @@ mod tests {
 
         let next = Uri::try_from("http://bar/baz").unwrap();
         match policy.check(StatusCode::FOUND, &HeaderMap::new(), &next, &[]) {
-            policy::Action::Follow => (),
+            redirect::Action::Follow => (),
             other => panic!("unexpected {other:?}"),
         }
 
         let next = Uri::try_from("http://foo/baz").unwrap();
         match policy.check(StatusCode::FOUND, &HeaderMap::new(), &next, &[]) {
-            policy::Action::Stop => (),
+            redirect::Action::Stop => (),
             other => panic!("unexpected {other:?}"),
         }
     }

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -488,7 +488,6 @@ async fn test_redirect_history() {
 
     let client = Client::builder()
         .redirect(Policy::default())
-        .history(true)
         .build()
         .unwrap();
 
@@ -500,20 +499,19 @@ async fn test_redirect_history() {
         &"test-dst"
     );
 
-    let history = res.extensions().get::<Vec<History>>().unwrap();
-    let mut history = history.iter();
+    let mut history = res.extensions().get::<History>().unwrap().into_iter();
 
     let next1 = history.next().unwrap();
-    assert_eq!(next1.status(), 302);
-    assert_eq!(next1.previous().path(), "/first");
-    assert_eq!(next1.uri().path(), "/second");
-    assert_eq!(next1.headers()["location"], "/second");
+    assert_eq!(next1.status, 302);
+    assert_eq!(next1.previous.path(), "/first");
+    assert_eq!(next1.uri.path(), "/second");
+    assert_eq!(next1.headers["location"], "/second");
 
     let next2 = history.next().unwrap();
-    assert_eq!(next2.status(), 302);
-    assert_eq!(next2.previous().path(), "/second");
-    assert_eq!(next2.uri().path(), "/dst");
-    assert_eq!(next2.headers()["location"], "/dst");
+    assert_eq!(next2.status, 302);
+    assert_eq!(next2.previous.path(), "/second");
+    assert_eq!(next2.uri.path(), "/dst");
+    assert_eq!(next2.headers["location"], "/dst");
 
     assert!(history.next().is_none());
 }


### PR DESCRIPTION
This update now records redirect history by default, removing the need to configure it through the cumbersome Client. It also refactors the API surface for redirect history entries