### PR TITLE
refactor(redirect): refactor handling of redirect history

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ tower = { version = "0.5.2", default-features = false, features = [
 ] }
 bytes = "1.10.1"
 http = "1.3.1"
-http2 = { version = "0.5.7", features = ["unstable"] }
+http2 = { version = "0.5.9", features = ["unstable"] }
 httparse = "1.10.1"
 http-body = "1.0.1"
 http-body-util = "0.1.3"

--- a/src/client/http.rs
+++ b/src/client/http.rs
@@ -220,7 +220,6 @@ struct Config {
     auto_sys_proxy: bool,
     retry_policy: retry::Policy,
     redirect_policy: redirect::Policy,
-    redirect_history: bool,
     referer: bool,
     timeout_options: TimeoutOptions,
     #[cfg(feature = "cookies")]
@@ -302,7 +301,6 @@ impl Client {
                 auto_sys_proxy: true,
                 retry_policy: retry::Policy::default(),
                 redirect_policy: redirect::Policy::none(),
-                redirect_history: false,
                 referer: true,
                 timeout_options: TimeoutOptions::default(),
                 #[cfg(feature = "hickory-dns")]
@@ -603,8 +601,7 @@ impl ClientBuilder {
                 .layer({
                     let policy = FollowRedirectPolicy::new(config.redirect_policy)
                         .with_referer(config.referer)
-                        .with_https_only(config.https_only)
-                        .with_history(config.redirect_history);
+                        .with_https_only(config.https_only);
                     FollowRedirectLayer::with_policy(policy)
                 })
                 .layer(ResponseBodyTimeoutLayer::new(config.timeout_options))
@@ -942,15 +939,6 @@ impl ClientBuilder {
     #[inline]
     pub fn redirect(mut self, policy: redirect::Policy) -> ClientBuilder {
         self.config.redirect_policy = policy;
-        self
-    }
-
-    /// Enable or disable redirect history tracking.
-    ///
-    /// Default is `false`.
-    #[inline]
-    pub fn history(mut self, enable: bool) -> ClientBuilder {
-        self.config.redirect_history = enable;
         self
     }
 

--- a/src/client/layer/redirect.rs
+++ b/src/client/layer/redirect.rs
@@ -1,109 +1,17 @@
 //! Middleware for following redirections.
 
 mod future;
-pub mod policy;
+mod layer;
+mod policy;
 
-use std::{
-    mem,
-    task::{Context, Poll},
-};
+use std::mem;
 
-use futures_util::future::Either;
-use http::{Request, Response};
 use http_body::Body;
-use tower::{Layer, Service};
 
-use self::{future::ResponseFuture, policy::Policy};
-use crate::error::BoxError;
-
-/// [`Layer`] for retrying requests with a [`Service`] to follow redirection responses.
-#[derive(Clone, Copy, Default)]
-pub struct FollowRedirectLayer<P> {
-    policy: P,
-}
-
-impl<P> FollowRedirectLayer<P> {
-    /// Create a new [`FollowRedirectLayer`] with the given redirection [`Policy`].
-    #[inline(always)]
-    pub const fn with_policy(policy: P) -> Self {
-        FollowRedirectLayer { policy }
-    }
-}
-
-impl<S, P> Layer<S> for FollowRedirectLayer<P>
-where
-    S: Clone,
-    P: Clone,
-{
-    type Service = FollowRedirect<S, P>;
-
-    #[inline(always)]
-    fn layer(&self, inner: S) -> Self::Service {
-        FollowRedirect::with_policy(inner, self.policy.clone())
-    }
-}
-
-/// Middleware that retries requests with a [`Service`] to follow redirection responses.
-#[derive(Clone, Copy)]
-pub struct FollowRedirect<S, P> {
-    inner: S,
-    policy: P,
-}
-
-impl<S, P> FollowRedirect<S, P>
-where
-    P: Clone,
-{
-    /// Create a new [`FollowRedirect`] with the given redirection [`Policy`].
-    #[inline(always)]
-    pub const fn with_policy(inner: S, policy: P) -> Self {
-        FollowRedirect { inner, policy }
-    }
-}
-
-impl<ReqBody, ResBody, S, P> Service<Request<ReqBody>> for FollowRedirect<S, P>
-where
-    S: Service<Request<ReqBody>, Response = Response<ResBody>> + Clone,
-    S::Error: From<BoxError>,
-    P: Policy<ReqBody, S::Error> + Clone,
-    ReqBody: Body + Default,
-{
-    type Response = Response<ResBody>;
-    type Error = S::Error;
-    type Future = ResponseFuture<S, ReqBody, P>;
-
-    #[inline(always)]
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner.poll_ready(cx)
-    }
-
-    fn call(&mut self, mut req: Request<ReqBody>) -> Self::Future {
-        let service = self.inner.clone();
-        let mut service = mem::replace(&mut self.inner, service);
-        let mut policy = self.policy.clone();
-        policy.on_extensions(req.extensions());
-
-        if policy.allowed() {
-            let mut clone_body = BodyRepr::None;
-            clone_body.try_clone_from(req.body(), &policy);
-            policy.on_request(&mut req);
-
-            let (parts, body) = req.into_parts();
-            ResponseFuture::Redirect {
-                future: Either::Left(service.call(Request::from_parts(parts.clone(), body))),
-                pending_future: None,
-                service,
-                policy,
-                parts,
-                body: clone_body,
-            }
-        } else {
-            ResponseFuture::Direct {
-                future: service.call(req),
-            }
-        }
-    }
-}
+pub use self::{
+    layer::{FollowRedirect, FollowRedirectLayer},
+    policy::{Action, Attempt, Policy},
+};
 
 enum BodyRepr<B> {
     Some(B),

--- a/src/client/layer/redirect/layer.rs
+++ b/src/client/layer/redirect/layer.rs
@@ -1,0 +1,101 @@
+use std::{
+    mem,
+    task::{Context, Poll},
+};
+
+use futures_util::future::Either;
+use http::{Request, Response};
+use http_body::Body;
+use tower::{Layer, Service};
+
+use super::{BodyRepr, future::ResponseFuture, policy::Policy};
+use crate::error::BoxError;
+
+/// [`Layer`] for retrying requests with a [`Service`] to follow redirection responses.
+#[derive(Clone, Copy, Default)]
+pub struct FollowRedirectLayer<P> {
+    policy: P,
+}
+
+impl<P> FollowRedirectLayer<P> {
+    /// Create a new [`FollowRedirectLayer`] with the given redirection [`Policy`].
+    #[inline(always)]
+    pub const fn with_policy(policy: P) -> Self {
+        FollowRedirectLayer { policy }
+    }
+}
+
+impl<S, P> Layer<S> for FollowRedirectLayer<P>
+where
+    S: Clone,
+    P: Clone,
+{
+    type Service = FollowRedirect<S, P>;
+
+    #[inline(always)]
+    fn layer(&self, inner: S) -> Self::Service {
+        FollowRedirect::with_policy(inner, self.policy.clone())
+    }
+}
+
+/// Middleware that retries requests with a [`Service`] to follow redirection responses.
+#[derive(Clone, Copy)]
+pub struct FollowRedirect<S, P> {
+    inner: S,
+    policy: P,
+}
+
+impl<S, P> FollowRedirect<S, P>
+where
+    P: Clone,
+{
+    /// Create a new [`FollowRedirect`] with the given redirection [`Policy`].
+    #[inline(always)]
+    pub const fn with_policy(inner: S, policy: P) -> Self {
+        FollowRedirect { inner, policy }
+    }
+}
+
+impl<ReqBody, ResBody, S, P> Service<Request<ReqBody>> for FollowRedirect<S, P>
+where
+    S: Service<Request<ReqBody>, Response = Response<ResBody>> + Clone,
+    S::Error: From<BoxError>,
+    P: Policy<ReqBody, S::Error> + Clone,
+    ReqBody: Body + Default,
+{
+    type Response = Response<ResBody>;
+    type Error = S::Error;
+    type Future = ResponseFuture<S, ReqBody, P>;
+
+    #[inline]
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: Request<ReqBody>) -> Self::Future {
+        let service = self.inner.clone();
+        let mut service = mem::replace(&mut self.inner, service);
+        let mut policy = self.policy.clone();
+
+        if policy.follow_redirects(req.extensions()) {
+            let mut body_repr = BodyRepr::None;
+            body_repr.try_clone_from(req.body(), &policy);
+            policy.on_request(&mut req);
+
+            let (parts, body) = req.into_parts();
+            let req = Request::from_parts(parts.clone(), body);
+            ResponseFuture::Redirect {
+                future: Either::Left(service.call(req)),
+                pending_future: None,
+                service,
+                policy,
+                parts,
+                body_repr,
+            }
+        } else {
+            ResponseFuture::Direct {
+                future: service.call(req),
+            }
+        }
+    }
+}

--- a/src/client/request.rs
+++ b/src/client/request.rs
@@ -804,8 +804,8 @@ where
             method,
             uri,
             headers,
-            body: Some(body.into()),
             extensions,
+            body: Some(body.into()),
         }
     }
 }

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -488,7 +488,6 @@ async fn test_redirect_history() {
 
     let client = Client::builder()
         .redirect(Policy::default())
-        .history(true)
         .build()
         .unwrap();
 
@@ -500,20 +499,19 @@ async fn test_redirect_history() {
         &"test-dst"
     );
 
-    let history = res.extensions().get::<Vec<History>>().unwrap();
-    let mut history = history.iter();
+    let mut history = res.extensions().get::<History>().unwrap().into_iter();
 
     let next1 = history.next().unwrap();
-    assert_eq!(next1.status(), 302);
-    assert_eq!(next1.previous().path(), "/first");
-    assert_eq!(next1.uri().path(), "/second");
-    assert_eq!(next1.headers()["location"], "/second");
+    assert_eq!(next1.status, 302);
+    assert_eq!(next1.previous.path(), "/first");
+    assert_eq!(next1.uri.path(), "/second");
+    assert_eq!(next1.headers["location"], "/second");
 
     let next2 = history.next().unwrap();
-    assert_eq!(next2.status(), 302);
-    assert_eq!(next2.previous().path(), "/second");
-    assert_eq!(next2.uri().path(), "/dst");
-    assert_eq!(next2.headers()["location"], "/dst");
+    assert_eq!(next2.status, 302);
+    assert_eq!(next2.previous.path(), "/second");
+    assert_eq!(next2.uri.path(), "/dst");
+    assert_eq!(next2.headers["location"], "/dst");
 
     assert!(history.next().is_none());
 }


### PR DESCRIPTION
This update now records redirect history by default, removing the need to configure it through the cumbersome Client. It also refactors the API surface for redirect history entries