### PR TITLE
feat(cookie): refactor `CookieStore` cookie compression strategy

### DIFF
--- a/src/client/core/ext/config.rs
+++ b/src/client/core/ext/config.rs
@@ -40,6 +40,7 @@ pub(crate) trait RequestConfigValue: Copy + Clone + 'static {
 pub(crate) struct RequestConfig<T: RequestConfigValue>(Option<T::Value>);
 
 impl<T: RequestConfigValue> Default for RequestConfig<T> {
+    #[inline]
     fn default() -> Self {
         RequestConfig(None)
     }

--- a/src/client/layer/config.rs
+++ b/src/client/layer/config.rs
@@ -24,6 +24,7 @@ impl RequestConfigValue for RequestTimeoutOptions {
 
 #[derive(Clone, Copy)]
 pub(crate) struct RequestRedirectPolicy;
+
 impl RequestConfigValue for RequestRedirectPolicy {
     type Value = Policy;
 }
@@ -49,6 +50,16 @@ impl RequestConfigValue for RequestAcceptEncoding {
 
 #[derive(Clone, Copy)]
 pub(crate) struct RequestDefaultHeaders;
+
 impl RequestConfigValue for RequestDefaultHeaders {
     type Value = bool;
+}
+
+#[cfg(feature = "cookies")]
+#[derive(Clone, Copy)]
+pub(crate) struct RequestCookieStore;
+
+#[cfg(feature = "cookies")]
+impl RequestConfigValue for RequestCookieStore {
+    type Value = std::sync::Arc<dyn crate::cookie::CookieStore>;
 }

--- a/src/client/request.rs
+++ b/src/client/request.rs
@@ -8,6 +8,8 @@ use std::{
 
 use http::{Extensions, Request as HttpRequest, Uri, Version, request::Parts};
 use serde::Serialize;
+#[cfg(feature = "cookies")]
+use {super::layer::config::RequestCookieStore, crate::cookie::IntoCookieStore};
 #[cfg(feature = "multipart")]
 use {super::multipart, bytes::Bytes, http::header::CONTENT_LENGTH};
 
@@ -134,6 +136,7 @@ impl Request {
     #[inline]
     pub fn version_mut(&mut self) -> &mut Option<Version> {
         self.config_mut::<RequestLayerOptions>()
+            .get_or_insert_default()
             .enforced_version_mut()
     }
 
@@ -174,12 +177,11 @@ impl Request {
     }
 
     #[inline]
-    fn config_mut<T>(&mut self) -> &mut T::Value
+    fn config_mut<T>(&mut self) -> &mut Option<T::Value>
     where
         T: RequestConfigValue,
-        T::Value: Default,
     {
-        RequestConfig::<T>::get_mut(&mut self.extensions).get_or_insert_default()
+        RequestConfig::<T>::get_mut(&mut self.extensions)
     }
 }
 
@@ -267,7 +269,8 @@ impl RequestBuilder {
     /// Set the original headers for this request.
     pub fn orig_headers(mut self, orig_headers: OrigHeaderMap) -> RequestBuilder {
         if let Ok(ref mut req) = self.request {
-            *req.config_mut::<RequestOrigHeaderMap>() = orig_headers;
+            req.config_mut::<RequestOrigHeaderMap>()
+                .get_or_insert(orig_headers);
         }
         self
     }
@@ -277,7 +280,8 @@ impl RequestBuilder {
     /// By default, client default headers are included. Set to `false` to skip them.
     pub fn default_headers(mut self, enable: bool) -> RequestBuilder {
         if let Ok(ref mut req) = self.request {
-            *req.config_mut::<RequestDefaultHeaders>() = enable;
+            req.config_mut::<RequestDefaultHeaders>()
+                .get_or_insert(enable);
         }
         self
     }
@@ -360,6 +364,7 @@ impl RequestBuilder {
     pub fn timeout(mut self, timeout: Duration) -> RequestBuilder {
         if let Ok(ref mut req) = self.request {
             req.config_mut::<RequestTimeoutOptions>()
+                .get_or_insert_default()
                 .total_timeout(timeout);
         }
         self
@@ -373,6 +378,7 @@ impl RequestBuilder {
     pub fn read_timeout(mut self, timeout: Duration) -> RequestBuilder {
         if let Ok(ref mut req) = self.request {
             req.config_mut::<RequestTimeoutOptions>()
+                .get_or_insert_default()
                 .read_timeout(timeout);
         }
         self
@@ -550,7 +556,22 @@ impl RequestBuilder {
     /// Set the redirect policy for this request.
     pub fn redirect(mut self, policy: redirect::Policy) -> RequestBuilder {
         if let Ok(ref mut req) = self.request {
-            *req.config_mut::<RequestRedirectPolicy>() = policy;
+            req.config_mut::<RequestRedirectPolicy>()
+                .get_or_insert(policy);
+        }
+        self
+    }
+
+    /// Set the persistent cookie store for the request.
+    #[cfg(feature = "cookies")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "cookies")))]
+    pub fn cookie_provider<C>(mut self, cookie_store: C) -> RequestBuilder
+    where
+        C: IntoCookieStore,
+    {
+        if let Ok(ref mut req) = self.request {
+            req.config_mut::<RequestCookieStore>()
+                .get_or_insert(cookie_store.into_cookie_store());
         }
         self
     }
@@ -560,7 +581,9 @@ impl RequestBuilder {
     #[cfg_attr(docsrs, doc(cfg(feature = "gzip")))]
     pub fn gzip(mut self, gzip: bool) -> RequestBuilder {
         if let Ok(ref mut req) = self.request {
-            req.config_mut::<RequestAcceptEncoding>().gzip(gzip);
+            req.config_mut::<RequestAcceptEncoding>()
+                .get_or_insert_default()
+                .gzip(gzip);
         }
         self
     }
@@ -570,7 +593,9 @@ impl RequestBuilder {
     #[cfg_attr(docsrs, doc(cfg(feature = "brotli")))]
     pub fn brotli(mut self, brotli: bool) -> RequestBuilder {
         if let Ok(ref mut req) = self.request {
-            req.config_mut::<RequestAcceptEncoding>().brotli(brotli);
+            req.config_mut::<RequestAcceptEncoding>()
+                .get_or_insert_default()
+                .brotli(brotli);
         }
         self
     }
@@ -580,7 +605,9 @@ impl RequestBuilder {
     #[cfg_attr(docsrs, doc(cfg(feature = "deflate")))]
     pub fn deflate(mut self, deflate: bool) -> RequestBuilder {
         if let Ok(ref mut req) = self.request {
-            req.config_mut::<RequestAcceptEncoding>().deflate(deflate);
+            req.config_mut::<RequestAcceptEncoding>()
+                .get_or_insert_default()
+                .deflate(deflate);
         }
         self
     }
@@ -590,7 +617,9 @@ impl RequestBuilder {
     #[cfg_attr(docsrs, doc(cfg(feature = "zstd")))]
     pub fn zstd(mut self, zstd: bool) -> RequestBuilder {
         if let Ok(ref mut req) = self.request {
-            req.config_mut::<RequestAcceptEncoding>().zstd(zstd);
+            req.config_mut::<RequestAcceptEncoding>()
+                .get_or_insert_default()
+                .zstd(zstd);
         }
         self
     }
@@ -598,8 +627,10 @@ impl RequestBuilder {
     /// Set the proxy for this request.
     pub fn proxy(mut self, proxy: Proxy) -> RequestBuilder {
         if let Ok(ref mut req) = self.request {
-            *req.config_mut::<RequestLayerOptions>().proxy_matcher_mut() =
-                Some(proxy.into_matcher());
+            req.config_mut::<RequestLayerOptions>()
+                .get_or_insert_default()
+                .proxy_matcher_mut()
+                .get_or_insert(proxy.into_matcher());
         }
         self
     }
@@ -611,6 +642,7 @@ impl RequestBuilder {
     {
         if let Ok(ref mut req) = self.request {
             req.config_mut::<RequestLayerOptions>()
+                .get_or_insert_default()
                 .tcp_connect_opts_mut()
                 .set_local_address(local_address.into());
         }
@@ -625,6 +657,7 @@ impl RequestBuilder {
     {
         if let Ok(ref mut req) = self.request {
             req.config_mut::<RequestLayerOptions>()
+                .get_or_insert_default()
                 .tcp_connect_opts_mut()
                 .set_local_addresses(ipv4, ipv6);
         }
@@ -665,6 +698,7 @@ impl RequestBuilder {
     {
         if let Ok(ref mut req) = self.request {
             req.config_mut::<RequestLayerOptions>()
+                .get_or_insert_default()
                 .tcp_connect_opts_mut()
                 .set_interface(interface);
         }
@@ -681,6 +715,7 @@ impl RequestBuilder {
             let (transport_opts, default_headers, orig_headers) = emulation.into_parts();
 
             req.config_mut::<RequestLayerOptions>()
+                .get_or_insert_default()
                 .transport_opts_mut()
                 .apply_transport_options(transport_opts);
 
@@ -691,16 +726,16 @@ impl RequestBuilder {
     }
 
     /// Build a `Request`, which can be inspected, modified and executed with
-    /// `Client::execute()`.
+    /// [`Client::execute()`].
     pub fn build(self) -> crate::Result<Request> {
         self.request
     }
 
     /// Build a `Request`, which can be inspected, modified and executed with
-    /// `Client::execute()`.
+    /// [`Client::execute()`].
     ///
     /// This is similar to [`RequestBuilder::build()`], but also returns the
-    /// embedded `Client`.
+    /// embedded [`Client`].
     pub fn build_split(self) -> (Client, crate::Result<Request>) {
         (self.client, self.request)
     }

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -73,7 +73,7 @@ where
 
         let computed_hash = NonZeroU64::new(self.hasher.hash_one(&self.value))
             .map(NonZeroU64::get)
-            .unwrap_or(u64::MIN | 1);
+            .unwrap_or(1);
 
         let _ = self.hash.compare_exchange(
             u64::MIN,


### PR DESCRIPTION
This commit restores the default compression strategy for better compatibility with many web servers.

close: https://github.com/0x676e67/wreq/issues/1003