### PR TITLE
refactor(layer): reorder decoder tower layers

### DIFF
--- a/src/client/layer/decoder.rs
+++ b/src/client/layer/decoder.rs
@@ -17,88 +17,26 @@ use crate::config::RequestConfig;
 #[derive(Clone)]
 pub(crate) struct AcceptEncoding {
     #[cfg(feature = "gzip")]
-    gzip: bool,
-
+    pub(crate) gzip: bool,
     #[cfg(feature = "brotli")]
-    brotli: bool,
-
+    pub(crate) brotli: bool,
     #[cfg(feature = "zstd")]
-    zstd: bool,
-
+    pub(crate) zstd: bool,
     #[cfg(feature = "deflate")]
-    deflate: bool,
+    pub(crate) deflate: bool,
 }
 
-/// Decompresses response bodies of the underlying service.
-///
-/// This adds the `Accept-Encoding` header to requests and transparently decompresses response
-/// bodies based on the `Content-Encoding` header.
+/// Layer that adds response body decompression to a service.
 #[derive(Clone)]
 pub struct DecompressionLayer {
     accept: AcceptEncoding,
 }
 
-impl DecompressionLayer {
-    /// Creates a new `DecompressionLayer` with the specified `AcceptEncoding`.
-    #[inline(always)]
-    pub const fn new(accept: AcceptEncoding) -> Self {
-        Self { accept }
-    }
-}
-
-impl<S> Layer<S> for DecompressionLayer {
-    type Service = Decompression<S>;
-
-    #[inline(always)]
-    fn layer(&self, service: S) -> Self::Service {
-        let decoder = decompression::Decompression::new(service);
-        let decoder = Decompression::<S>::accept_in_place(decoder, &self.accept);
-        Decompression {
-            decoder: Some(decoder),
-        }
-    }
-}
-
-/// Decompresses response bodies of the underlying service.
-///
-/// This adds the `Accept-Encoding` header to requests and transparently decompresses response
-/// bodies based on the `Content-Encoding` header.
+/// Service that decompresses response bodies based on the [`AcceptEncoding`] configuration.
 #[derive(Clone)]
-pub struct Decompression<S> {
-    decoder: Option<decompression::Decompression<S>>,
-}
+pub struct Decompression<S>(Option<decompression::Decompression<S>>);
 
 // ===== AcceptEncoding =====
-
-impl AcceptEncoding {
-    /// Enable or disable gzip decoding.
-    #[inline(always)]
-    #[cfg(feature = "gzip")]
-    pub fn gzip(&mut self, enabled: bool) {
-        self.gzip = enabled;
-    }
-
-    /// Enable or disable brotli decoding.
-    #[inline(always)]
-    #[cfg(feature = "brotli")]
-    pub fn brotli(&mut self, enabled: bool) {
-        self.brotli = enabled;
-    }
-
-    /// Enable or disable zstd decoding.
-    #[inline(always)]
-    #[cfg(feature = "zstd")]
-    pub fn zstd(&mut self, enabled: bool) {
-        self.zstd = enabled;
-    }
-
-    /// Enable or disable deflate decoding.
-    #[inline(always)]
-    #[cfg(feature = "deflate")]
-    pub fn deflate(&mut self, enabled: bool) {
-        self.deflate = enabled;
-    }
-}
 
 impl Default for AcceptEncoding {
     fn default() -> AcceptEncoding {
@@ -117,10 +55,33 @@ impl Default for AcceptEncoding {
 
 impl_request_config_value!(AcceptEncoding);
 
+// ===== impl DecompressionLayer =====
+
+impl DecompressionLayer {
+    /// Creates a new [`DecompressionLayer`] with the specified [`AcceptEncoding`].
+    #[inline(always)]
+    pub const fn new(accept: AcceptEncoding) -> Self {
+        Self { accept }
+    }
+}
+
+impl<S> Layer<S> for DecompressionLayer {
+    type Service = Decompression<S>;
+
+    #[inline(always)]
+    fn layer(&self, service: S) -> Self::Service {
+        Decompression(Some(Decompression::<S>::accept_in_place(
+            decompression::Decompression::new(service),
+            &self.accept,
+        )))
+    }
+}
+
 // ===== impl Decompression =====
 
 impl<S> Decompression<S> {
-    // replaces the current decoder with a new one based on the `AcceptEncoding`.
+    const BUG_MSG: &str = "[BUG] Decompression service not initialized; bug in setup";
+
     fn accept_in_place(
         mut decoder: decompression::Decompression<S>,
         accept: &AcceptEncoding,
@@ -151,7 +112,7 @@ impl<S> Decompression<S> {
 
 impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for Decompression<S>
 where
-    S: Service<Request<ReqBody>, Response = Response<ResBody>> + Clone,
+    S: Service<Request<ReqBody>, Response = Response<ResBody>>,
     ReqBody: Body,
     ResBody: Body,
 {
@@ -161,33 +122,18 @@ where
 
     #[inline(always)]
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        match self.decoder.as_mut() {
-            Some(decoder) => decoder.poll_ready(cx),
-            None => unreachable!("Decompression service is not initialized"),
-        }
+        self.0.as_mut().expect(Self::BUG_MSG).poll_ready(cx)
     }
 
     fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
-        // If the accept encoding is set, we need to update the decoder
-        // to handle the specified encodings.
+        // Update decoder if accept encoding is set.
         if let Some(accept) = RequestConfig::<AcceptEncoding>::get(req.extensions()) {
-            if let Some(mut decoder) = self.decoder.take() {
-                decoder = Decompression::accept_in_place(decoder, accept);
-                self.decoder = Some(decoder);
+            if let Some(decoder) = self.0.take() {
+                self.0
+                    .replace(Decompression::accept_in_place(decoder, accept));
             }
         }
 
-        // Call the underlying service with the request
-        match self.decoder.as_mut() {
-            Some(decoder) => decoder.call(req),
-            None => {
-                // This branch should never be reached: decoder is always initialized in
-                // DecompressionLayer::layer(). If this panic occurs, it indicates a
-                // bug in the service setup or unexpected internal state.
-                unreachable!(
-                    "Decompression service was not initialized; this indicates a bug in service setup"
-                );
-            }
-        }
+        self.0.as_mut().expect(Self::BUG_MSG).call(req)
     }
 }

--- a/src/client/layer/retry.rs
+++ b/src/client/layer/retry.rs
@@ -10,19 +10,12 @@ use tower::retry::{
     Policy,
     budget::{Budget, TpsBudget},
 };
-#[cfg(any(
-    feature = "gzip",
-    feature = "zstd",
-    feature = "brotli",
-    feature = "deflate",
-))]
-use tower_http::decompression::DecompressionBody;
 
 pub(crate) use self::{
     classify::{Action, Classifier, ClassifyFn, ReqRep},
     scope::{ScopeFn, Scoped},
 };
-use super::{super::core::body::Incoming, timeout::TimeoutBody};
+use super::super::core::body::Incoming;
 use crate::{Body, error::BoxError, retry};
 
 /// A retry policy for HTTP requests.
@@ -53,21 +46,7 @@ impl RetryPolicy {
 
 type Req = Request<Body>;
 
-#[cfg(not(any(
-    feature = "gzip",
-    feature = "zstd",
-    feature = "brotli",
-    feature = "deflate",
-)))]
-type Res = Response<TimeoutBody<Incoming>>;
-
-#[cfg(any(
-    feature = "gzip",
-    feature = "zstd",
-    feature = "brotli",
-    feature = "deflate",
-))]
-type Res = Response<TimeoutBody<DecompressionBody<Incoming>>>;
+type Res = Response<Incoming>;
 
 impl Policy<Req, Res, BoxError> for RetryPolicy {
     type Future = std::future::Ready<()>;

--- a/src/client/request.rs
+++ b/src/client/request.rs
@@ -562,7 +562,7 @@ impl RequestBuilder {
         if let Ok(ref mut req) = self.request {
             req.config_mut::<AcceptEncoding>()
                 .get_or_insert_default()
-                .gzip(gzip);
+                .gzip = gzip;
         }
         self
     }
@@ -574,7 +574,7 @@ impl RequestBuilder {
         if let Ok(ref mut req) = self.request {
             req.config_mut::<AcceptEncoding>()
                 .get_or_insert_default()
-                .brotli(brotli);
+                .brotli = brotli;
         }
         self
     }
@@ -586,7 +586,7 @@ impl RequestBuilder {
         if let Ok(ref mut req) = self.request {
             req.config_mut::<AcceptEncoding>()
                 .get_or_insert_default()
-                .deflate(deflate);
+                .deflate = deflate;
         }
         self
     }
@@ -598,7 +598,7 @@ impl RequestBuilder {
         if let Ok(ref mut req) = self.request {
             req.config_mut::<AcceptEncoding>()
                 .get_or_insert_default()
-                .zstd(zstd);
+                .zstd = zstd;
         }
         self
     }


### PR DESCRIPTION
effectively reduce the boilerplate code of the tower middleware