### PR TITLE
fix(proxy): skip proxy headers for HTTPS destinations

### DIFF
--- a/src/client/layer/config.rs
+++ b/src/client/layer/config.rs
@@ -130,6 +130,12 @@ where
         // store the original headers in request extensions
         self.config.orig_headers.store(req.extensions_mut());
 
+        // skip proxy headers for HTTPS destinations.
+        // for HTTPS, the proxy headers are part of the CONNECT tunnel instead.
+        if uri.is_https() {
+            return Either::Left(self.inner.call(req));
+        }
+
         // determine the proxy matcher to use
         match RequestConfig::<RequestOptions>::get(req.extensions())
             .and_then(RequestOptions::proxy_matcher)


### PR DESCRIPTION
## Summary
Fix regression where `Proxy-Authorization` header was sent to HTTPS target servers instead of only in the CONNECT tunnel.
When ConfigService moved from `src/client/http/service.rs` to `src/client/layer/config.rs`, the HTTPS check was not carried over.

## Test
Request to `https://tls.peet.ws/api/all` through an authenticated HTTP proxy no longer includes `proxy-authorization` in the headers received by the target.
