### PR TITLE
build(deps): update `http2` dependency version to 0.5.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ tower = { version = "0.5.2", default-features = false, features = [
 ] }
 bytes = "1.10.1"
 http = "1.3.1"
-http2 = { version = "0.5.9", features = ["unstable"] }
+http2 = { version = "0.5.11", features = ["unstable"] }
 httparse = "1.10.1"
 http-body = "1.0.1"
 http-body-util = "0.1.3"


### PR DESCRIPTION
fix: https://github.com/hyperium/h2/issues/853