### PR TITLE
build(deps): Bump `url` dependency version to 2.5.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ tracing = ["http2/tracing", "dep:tracing"]
 
 [dependencies]
 percent-encoding = "2.3.2"
-url = "2.5.7"
+url = "2.5.8"
 tower = { version = "0.5.2", default-features = false, features = [
     "timeout",
     "util",


### PR DESCRIPTION
Update url dependency version from 2.5.7 to 2.5.8.