### PR TITLE
fix(http1): use case-insensitive matching for trailer fields

### DIFF
--- a/src/client/core/proto/h1/encode.rs
+++ b/src/client/core/proto/h1/encode.rs
@@ -1,11 +1,11 @@
-use std::{collections::HashMap, fmt, io::IoSlice};
+use std::{collections::HashSet, fmt, io::IoSlice};
 
 use bytes::{
     Buf, Bytes,
     buf::{Chain, Take},
 };
 use http::{
-    HeaderMap, HeaderName, HeaderValue,
+    HeaderMap, HeaderName,
     header::{
         AUTHORIZATION, CACHE_CONTROL, CONTENT_ENCODING, CONTENT_LENGTH, CONTENT_RANGE,
         CONTENT_TYPE, HOST, MAX_FORWARDS, SET_COOKIE, TE, TRAILER, TRANSFER_ENCODING,
@@ -34,7 +34,7 @@ pub(crate) struct NotEof(u64);
 #[derive(Debug, PartialEq, Clone)]
 enum Kind {
     /// An Encoder for when Transfer-Encoding includes `chunked`.
-    Chunked(Option<Vec<HeaderValue>>),
+    Chunked(Option<Vec<HeaderName>>),
     /// An Encoder for when Content-Length is set.
     ///
     /// Enforces that the body is not longer than the Content-Length header.
@@ -65,7 +65,7 @@ impl Encoder {
         Encoder::new(Kind::Length(len))
     }
 
-    pub(crate) fn into_chunked_with_trailing_fields(self, trailers: Vec<HeaderValue>) -> Encoder {
+    pub(crate) fn into_chunked_with_trailing_fields(self, trailers: Vec<HeaderName>) -> Encoder {
         match self.kind {
             Kind::Chunked(_) => Encoder {
                 kind: Kind::Chunked(Some(trailers)),
@@ -135,7 +135,7 @@ impl Encoder {
         trace!("encoding trailers");
         match &self.kind {
             Kind::Chunked(Some(allowed_trailer_fields)) => {
-                let allowed_trailer_field_map = allowed_trailer_field_map(allowed_trailer_fields);
+                let allowed_set: HashSet<&HeaderName> = allowed_trailer_fields.iter().collect();
 
                 let mut cur_name = None;
                 let mut allowed_trailers = HeaderMap::new();
@@ -146,7 +146,7 @@ impl Encoder {
                     }
                     let name = cur_name.as_ref().expect("current header name");
 
-                    if allowed_trailer_field_map.contains_key(name.as_str()) {
+                    if allowed_set.contains(name) {
                         if is_valid_trailer_field(name) {
                             allowed_trailers.insert(name, value);
                         } else {
@@ -234,22 +234,6 @@ fn is_valid_trailer_field(name: &HeaderName) -> bool {
             | TRANSFER_ENCODING
             | TE
     )
-}
-
-fn allowed_trailer_field_map(allowed_trailer_fields: &Vec<HeaderValue>) -> HashMap<String, ()> {
-    let mut trailer_map = HashMap::new();
-
-    for header_value in allowed_trailer_fields {
-        if let Ok(header_str) = header_value.to_str() {
-            let items: Vec<&str> = header_str.split(',').map(|item| item.trim()).collect();
-
-            for item in items {
-                trailer_map.entry(item.to_string()).or_insert(());
-            }
-        }
-    }
-
-    trailer_map
 }
 
 impl<B> Buf for EncodedBuf<B>
@@ -465,7 +449,7 @@ mod tests {
     #[test]
     fn chunked_with_valid_trailers() {
         let encoder = Encoder::chunked();
-        let trailers = vec![HeaderValue::from_static("chunky-trailer")];
+        let trailers = vec![HeaderName::from_static("chunky-trailer")];
         let encoder = encoder.into_chunked_with_trailing_fields(trailers);
 
         let headers = HeaderMap::from_iter(vec![
@@ -490,8 +474,8 @@ mod tests {
     fn chunked_with_multiple_trailer_headers() {
         let encoder = Encoder::chunked();
         let trailers = vec![
-            HeaderValue::from_static("chunky-trailer"),
-            HeaderValue::from_static("chunky-trailer-2"),
+            HeaderName::from_static("chunky-trailer"),
+            HeaderName::from_static("chunky-trailer-2"),
         ];
         let encoder = encoder.into_chunked_with_trailing_fields(trailers);
 
@@ -537,10 +521,14 @@ mod tests {
     fn chunked_with_invalid_trailers() {
         let encoder = Encoder::chunked();
 
-        let trailers = format!(
-            "{AUTHORIZATION},{CACHE_CONTROL},{CONTENT_ENCODING},{CONTENT_LENGTH},{CONTENT_RANGE},{CONTENT_TYPE},{HOST},{MAX_FORWARDS},{SET_COOKIE},{TRAILER},{TRANSFER_ENCODING},{TE}",
-        );
-        let trailers = vec![HeaderValue::from_str(&trailers).unwrap()];
+        let trailers = vec![
+            AUTHORIZATION,
+            CACHE_CONTROL,
+            CONTENT_ENCODING,
+            TRAILER,
+            TRANSFER_ENCODING,
+            TE,
+        ];
         let encoder = encoder.into_chunked_with_trailing_fields(trailers);
 
         let mut headers = HeaderMap::new();
@@ -558,5 +546,35 @@ mod tests {
         headers.insert(TE, HeaderValue::from_static("header data"));
 
         assert!(encoder.encode_trailers::<&[u8]>(headers).is_none());
+    }
+
+    #[test]
+    fn chunked_trailers_case_insensitive_matching() {
+        // Regression test for issue #4010: HTTP/1.1 trailers are case-sensitive
+        //
+        // Previously, the Trailer header values were stored as HeaderValue (preserving case)
+        // and compared against HeaderName (which is always lowercase). This caused trailers
+        // declared as "Chunky-Trailer" to not match actual trailers sent as "chunky-trailer".
+        //
+        // The fix converts Trailer header values to HeaderName during parsing, which
+        // normalizes the case and enables proper case-insensitive matching.
+        //
+        // Note: HeaderName::from_static() requires lowercase input. In real usage,
+        // HeaderName::from_bytes() is used to parse the Trailer header value, which
+        // normalizes mixed-case input like "Chunky-Trailer" to "chunky-trailer".
+        let encoder = Encoder::chunked();
+        let trailers = vec![HeaderName::from_static("chunky-trailer")];
+        let encoder = encoder.into_chunked_with_trailing_fields(trailers);
+
+        // The actual trailer being sent
+        let headers = HeaderMap::from_iter(vec![(
+            HeaderName::from_static("chunky-trailer"),
+            HeaderValue::from_static("trailer value"),
+        )]);
+
+        let buf = encoder.encode_trailers::<&[u8]>(headers).unwrap();
+        let mut dst = Vec::new();
+        dst.put(buf);
+        assert_eq!(dst, b"0\r\nchunky-trailer: trailer value\r\n\r\n");
     }
 }


### PR DESCRIPTION
backport: https://github.com/hyperium/hyper/commit/3b344cac9f96a9365409086dde51d06aa797ffc3