### PR TITLE
fix(rt): support fake time in legacy client and TokioTimer

### DIFF
--- a/src/client/http/client/pool.rs
+++ b/src/client/http/client/pool.rs
@@ -966,7 +966,6 @@ mod tests {
     }
 
     #[tokio::test]
-
     async fn test_pool_timer_removes_expired_realtime() {
         test_pool_timer_removes_expired_inner().await
     }


### PR DESCRIPTION
backport: https://github.com/hyperium/hyper-util/commit/d91ea8efe6f3b09cc2fd6cc9e303566bd887a3ea