### PR TITLE
fix(http1): allow keep-alive for chunked requests with trailers

### DIFF
--- a/src/client/core/proto/http1/conn.rs
+++ b/src/client/core/proto/http1/conn.rs
@@ -286,7 +286,8 @@ where
                             };
                             (reading, Poll::Ready(maybe_frame))
                         } else if frame.is_trailers() {
-                            (Reading::Closed, Poll::Ready(Some(Ok(frame))))
+                            debug!("incoming body completed with trailers");
+                            (Reading::KeepAlive, Poll::Ready(Some(Ok(frame))))
                         } else {
                             trace!("discarding unknown frame");
                             (Reading::Closed, Poll::Ready(None))


### PR DESCRIPTION
backport: https://github.com/hyperium/hyper/commit/7211ec25eff2ea6ee783817fee2a221d4eb2ed03