### PR TITLE
fix(http2): cancel pipe_task and send RST_STREAM on response future drop

### DIFF
--- a/src/client/core/dispatch.rs
+++ b/src/client/core/dispatch.rs
@@ -289,6 +289,9 @@ where
                     }
                 };
                 trace!("send_when canceled");
+                // Tell pipe_task to reset the h2 stream so that
+                // RST_STREAM is sent and flow-control capacity freed.
+                this.when.as_mut().cancel();
                 Poll::Ready(())
             }
             Poll::Ready(Err((error, message))) => {

--- a/src/client/core/proto/http2.rs
+++ b/src/client/core/proto/http2.rs
@@ -107,9 +107,28 @@ pin_project! {
         S: Body,
     {
         #[pin]
-        body: S,
+        stream: S,
         body_tx: SendStream<SendBuf<S::Data>>,
         data_done: bool,
+    }
+}
+
+impl<S> PipeToSendStream<S>
+where
+    S: Body,
+{
+    #[inline]
+    fn new(stream: S, body_tx: SendStream<SendBuf<S::Data>>) -> PipeToSendStream<S> {
+        PipeToSendStream {
+            stream,
+            body_tx,
+            data_done: false,
+        }
+    }
+
+    #[inline]
+    fn send_reset(self: Pin<&mut Self>, reason: http2::Reason) {
+        self.project().body_tx.send_reset(reason);
     }
 }
 
@@ -153,11 +172,11 @@ where
                 return Poll::Ready(Err(Error::new_body_write(::http2::Error::from(reason))));
             }
 
-            match ready!(me.body.as_mut().poll_frame(cx)) {
+            match ready!(me.stream.as_mut().poll_frame(cx)) {
                 Some(Ok(frame)) => {
                     if frame.is_data() {
                         let chunk = frame.into_data().unwrap_or_else(|_| unreachable!());
-                        let is_eos = me.body.is_end_stream();
+                        let is_eos = me.stream.is_end_stream();
                         trace!(
                             "send body chunk: {} bytes, eos={}",
                             chunk.remaining(),
@@ -832,5 +851,62 @@ impl Default for Http2Options {
             headers_stream_dependency: None,
             priorities: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use bytes::Bytes;
+    use futures_channel::oneshot;
+    use http_body_util::Full;
+
+    use super::core::{conn::http2::Builder, rt::TokioExecutor};
+
+    fn setup_duplex_test_server() -> (tokio::io::DuplexStream, tokio::io::DuplexStream) {
+        let (client_io, server_io) = tokio::io::duplex(64);
+        (client_io, server_io)
+    }
+
+    // https://github.com/hyperium/hyper/issues/4040
+    #[tokio::test]
+    async fn h2_pipe_task_cancelled_on_response_future_drop() {
+        let (client_io, server_io) = setup_duplex_test_server();
+        let (rst_tx, rst_rx) = oneshot::channel::<bool>();
+
+        tokio::spawn(async move {
+            let mut builder = http2::server::Builder::new();
+            builder.initial_window_size(0);
+            let mut h2 = builder.handshake::<_, Bytes>(server_io).await.unwrap();
+            let (req, _respond) = h2.accept().await.unwrap().unwrap();
+            tokio::spawn(async move {
+                let _ = std::future::poll_fn(|cx| h2.poll_closed(cx)).await;
+            });
+
+            let mut body = req.into_body();
+            let got_rst = tokio::time::timeout(Duration::from_secs(2), body.data())
+                .await
+                .is_ok_and(|frame| matches!(frame, Some(Err(_)) | None));
+            let _ = rst_tx.send(got_rst);
+        });
+
+        let (mut client, conn) = Builder::new(TokioExecutor::new())
+            .handshake(client_io)
+            .await
+            .expect("http handshake");
+        tokio::spawn(async move {
+            let _ = conn.await;
+        });
+
+        let req = http::Request::post("http://localhost/")
+            .body(Full::new(Bytes::from(vec![b'x'; 50])))
+            .unwrap();
+        let res =
+            tokio::time::timeout(Duration::from_millis(5), client.try_send_request(req)).await;
+        assert!(res.is_err(), "should timeout waiting for response");
+
+        let got_rst = rst_rx.await.expect("server task should complete");
+        assert!(got_rst, "server should receive RST_STREAM");
     }
 }

--- a/src/client/core/proto/http2/client.rs
+++ b/src/client/core/proto/http2/client.rs
@@ -345,6 +345,7 @@ pin_project! {
         conn_drop_ref: Option<Sender<Infallible>>,
         #[pin]
         ping: Option<Recorder>,
+        cancel_rx: Option<oneshot::Receiver<()>>,
     }
 }
 
@@ -356,15 +357,36 @@ where
     type Output = ();
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> std::task::Poll<Self::Output> {
+        const EXPECT_TAKEN_ONCE_MSG: &str = "Future polled twice";
+
         let mut this = self.project();
+
+        // Check if the client cancelled the request (e.g. dropped the
+        // response future due to a timeout). If so, reset the h2 stream
+        // so that a RST_STREAM is sent and flow-control capacity is freed.
+        match this.cancel_rx.as_mut().map(|rx| Pin::new(rx).poll(cx)) {
+            Some(Poll::Ready(Ok(()))) => {
+                debug!("client request body send cancelled, resetting stream");
+                this.pipe.as_mut().send_reset(http2::Reason::CANCEL);
+                this.conn_drop_ref.take().expect(EXPECT_TAKEN_ONCE_MSG);
+                this.ping.take().expect(EXPECT_TAKEN_ONCE_MSG);
+                return Poll::Ready(());
+            }
+            Some(Poll::Ready(Err(_))) => {
+                // Sender dropped without cancelling (normal response or error).
+                // Stop polling the receiver.
+                *this.cancel_rx = None;
+            }
+            Some(Poll::Pending) | None => {}
+        }
 
         match Pin::new(&mut this.pipe).poll(cx) {
             Poll::Ready(result) => {
                 if let Err(_e) = result {
                     debug!("client request body error: {}", _e);
                 }
-                drop(this.conn_drop_ref.take().expect("Future polled twice"));
-                drop(this.ping.take().expect("Future polled twice"));
+                drop(this.conn_drop_ref.take().expect(EXPECT_TAKEN_ONCE_MSG));
+                drop(this.ping.take().expect(EXPECT_TAKEN_ONCE_MSG));
                 return Poll::Ready(());
             }
             Poll::Pending => (),
@@ -384,13 +406,13 @@ where
     fn poll_pipe(&mut self, f: FutCtx<B>, cx: &mut Context<'_>) {
         let ping = self.ping.clone();
 
+        // A one-shot channel so that send_task can tell pipe_task to
+        // reset the stream when the client cancels the request.
+        let (cancel_tx, cancel_rx) = oneshot::channel::<()>();
+
         let send_stream = if !f.is_connect {
             if !f.eos {
-                let mut pipe = PipeToSendStream {
-                    body: f.body,
-                    body_tx: f.body_tx,
-                    data_done: false,
-                };
+                let mut pipe = PipeToSendStream::new(f.body, f.body_tx);
 
                 // eagerly see if the body pipe is ready and
                 // can thus skip allocating in the executor
@@ -407,6 +429,7 @@ where
                             pipe,
                             conn_drop_ref: Some(conn_drop_ref),
                             ping: Some(ping),
+                            cancel_rx: Some(cancel_rx),
                         };
                         // Clear send task
                         self.executor
@@ -426,6 +449,7 @@ where
                     fut: f.fut,
                     ping: Some(ping),
                     send_stream: Some(send_stream),
+                    cancel_tx: Some(cancel_tx),
                 },
                 call_back: Some(f.cb),
             },
@@ -445,6 +469,16 @@ pin_project! {
         ping: Option<Recorder>,
         #[pin]
         send_stream: Option<Option<SendStream<SendBuf<<B as Body>::Data>>>>,
+        cancel_tx: Option<oneshot::Sender<()>>,
+    }
+}
+
+impl<B: Body + 'static> ResponseFutMap<B> {
+    /// Signal the pipe_task to reset the stream (e.g. on client cancellation).
+    pub(crate) fn cancel(self: Pin<&mut Self>) {
+        if let Some(cancel_tx) = self.project().cancel_tx.take() {
+            let _ = cancel_tx.send(());
+        }
     }
 }
 


### PR DESCRIPTION
backport: https://github.com/hyperium/hyper/pull/4042/changes/927f8b25992b13bf2b030c8ea22d14996a70e34c