### PR TITLE
build(deps): reduce dependency on `futures-channel`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,6 @@ http-body = "1.0.1"
 http-body-util = "0.1.3"
 want = "0.3.1"
 pin-project-lite = "0.2.17"
-futures-channel = "0.3.32"
 futures-util = { version = "0.3.32", default-features = false }
 smallvec = { version = "1.15.1", features = ["const_generics", "const_new"] }
 socket2 = { version = "0.6.3", features = ["all"] }

--- a/src/client/core/body/incoming.rs
+++ b/src/client/core/body/incoming.rs
@@ -1,15 +1,14 @@
 use std::{
     fmt,
-    future::Future,
     pin::Pin,
     task::{Context, Poll, ready},
 };
 
 use bytes::Bytes;
-use futures_channel::{mpsc, oneshot};
-use futures_util::{FutureExt, Stream, stream::FusedStream};
 use http::HeaderMap;
 use http_body::{Body, Frame, SizeHint};
+use tokio::sync::{mpsc, oneshot};
+use tokio_util::sync::PollSender;
 
 use super::{DecodedLength, watch};
 use crate::client::core::{Error, Result, proto::http2::ping};
@@ -25,16 +24,17 @@ pub struct Incoming {
 
 enum Kind {
     H1 {
-        content_length: DecodedLength,
         want_tx: watch::Sender,
         data_rx: mpsc::Receiver<Result<Bytes, Error>>,
         trailers_rx: oneshot::Receiver<HeaderMap>,
-    },
-    H2 {
         content_length: DecodedLength,
         data_done: bool,
+    },
+    H2 {
         ping: ping::Recorder,
         recv: http2::RecvStream,
+        content_length: DecodedLength,
+        data_done: bool,
     },
     Empty,
 }
@@ -55,9 +55,11 @@ enum Kind {
 #[must_use = "Sender does nothing unless sent on"]
 pub(crate) struct Sender {
     want_rx: watch::Receiver,
-    data_tx: mpsc::Sender<Result<Bytes, Error>>,
+    data_tx: PollSender<Result<Bytes, Error>>,
     trailers_tx: Option<oneshot::Sender<HeaderMap>>,
 }
+
+// ===== impl Incoming =====
 
 impl Incoming {
     #[inline]
@@ -66,7 +68,7 @@ impl Incoming {
     }
 
     pub(crate) fn h1(content_length: DecodedLength, wanter: bool) -> (Sender, Incoming) {
-        let (data_tx, data_rx) = mpsc::channel(0);
+        let (data_tx, data_rx) = mpsc::channel(1);
         let (trailers_tx, trailers_rx) = oneshot::channel();
         // If wanter is true, `Sender::poll_ready()` won't becoming ready
         // until the `Body` has been polled for data once.
@@ -75,15 +77,16 @@ impl Incoming {
         (
             Sender {
                 want_rx,
-                data_tx,
+                data_tx: PollSender::new(data_tx),
                 trailers_tx: Some(trailers_tx),
             },
             Incoming {
                 kind: Kind::H1 {
-                    content_length,
                     want_tx,
                     data_rx,
                     trailers_rx,
+                    content_length,
+                    data_done: false,
                 },
             },
         )
@@ -102,10 +105,10 @@ impl Incoming {
 
         Incoming {
             kind: Kind::H2 {
-                data_done: false,
                 ping,
-                content_length,
                 recv,
+                content_length,
+                data_done: false,
             },
         }
     }
@@ -121,37 +124,48 @@ impl Body for Incoming {
     ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
         match self.kind {
             Kind::H1 {
-                content_length: ref mut len,
+                ref want_tx,
                 ref mut data_rx,
-                ref mut want_tx,
                 ref mut trailers_rx,
+                ref mut content_length,
+                ref mut data_done,
             } => {
-                want_tx.send(watch::Value::Ready);
+                want_tx.ready();
 
-                if !data_rx.is_terminated() {
-                    if let Some(chunk) = ready!(Pin::new(data_rx).poll_next(cx)?) {
-                        len.sub_if(chunk.len() as u64);
-                        return Poll::Ready(Some(Ok(Frame::data(chunk))));
+                if !*data_done {
+                    match ready!(data_rx.poll_recv(cx)) {
+                        Some(Ok(chunk)) => {
+                            content_length.sub_if(chunk.len() as u64);
+                            return Poll::Ready(Some(Ok(Frame::data(chunk))));
+                        }
+                        Some(Err(err)) => return Poll::Ready(Some(Err(err))),
+                        None => {
+                            // fall through to trailers
+                            *data_done = true;
+                        }
                     }
                 }
 
                 // check trailers after data is terminated
-                match ready!(Pin::new(trailers_rx).poll(cx)) {
-                    Ok(t) => Poll::Ready(Some(Ok(Frame::trailers(t)))),
-                    Err(_) => Poll::Ready(None),
+                if !trailers_rx.is_terminated() {
+                    if let Ok(trailers) = ready!(Pin::new(trailers_rx).poll(cx)) {
+                        return Poll::Ready(Some(Ok(Frame::trailers(trailers))));
+                    }
                 }
+
+                Poll::Ready(None)
             }
             Kind::H2 {
-                ref mut data_done,
                 ref ping,
-                recv: ref mut h2,
-                content_length: ref mut len,
+                ref mut recv,
+                ref mut content_length,
+                ref mut data_done,
             } => {
                 if !*data_done {
-                    match ready!(h2.poll_data(cx)) {
+                    match ready!(recv.poll_data(cx)) {
                         Some(Ok(bytes)) => {
-                            let _ = h2.flow_control().release_capacity(bytes.len());
-                            len.sub_if(bytes.len() as u64);
+                            let _ = recv.flow_control().release_capacity(bytes.len());
+                            content_length.sub_if(bytes.len() as u64);
                             ping.record_data(bytes.len());
                             return Poll::Ready(Some(Ok(Frame::data(bytes))));
                         }
@@ -167,14 +181,14 @@ impl Body for Incoming {
                             };
                         }
                         None => {
-                            *data_done = true;
                             // fall through to trailers
+                            *data_done = true;
                         }
                     }
                 }
 
                 // after data, check trailers
-                match ready!(h2.poll_trailers(cx)) {
+                match ready!(recv.poll_trailers(cx)) {
                     Ok(t) => {
                         ping.record_non_data();
                         Poll::Ready(Ok(t.map(Frame::trailers)).transpose())
@@ -217,57 +231,63 @@ impl fmt::Debug for Incoming {
     }
 }
 
+// ===== impl Sender =====
+
 impl Sender {
     /// Check to see if this `Sender` can send more data.
+    #[inline]
     pub(crate) fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<()>> {
         // Check if the receiver end has tried polling for the body yet
-        ready!(self.want_rx.poll_unpin(cx)?);
-        self.data_tx.poll_ready(cx).map_err(|_| Error::new_closed())
+        ready!(self.want_rx.poll_ready(cx)?);
+        self.data_tx
+            .poll_reserve(cx)
+            .map_err(|_| Error::new_closed())
     }
 
-    /// Try to send data on this channel.
+    /// Send data on this channel.
     ///
     /// # Errors
     ///
     /// Returns `Err(Bytes)` if the channel could not (currently) accept
     /// another `Bytes`.
     ///
-    /// # Note
+    /// # Panics
     ///
-    /// This is mostly useful for when trying to send from some other thread
-    /// that doesn't have an async context. If in an async context, prefer
-    /// `send_data()` instead.
+    /// If `poll_ready` was not successfully called prior to calling `send_data`, then this method
+    /// will panic.
     #[inline]
-    pub(crate) fn try_send_data(&mut self, chunk: Bytes) -> Result<(), Bytes> {
-        self.data_tx
-            .try_send(Ok(chunk))
-            .map_err(|err| err.into_inner().expect("just sent Ok"))
+    pub(crate) fn send_data(&mut self, chunk: Bytes) -> Result<(), Bytes> {
+        self.data_tx.send_item(Ok(chunk)).map_err(|err| {
+            err.into_inner()
+                .expect("value returned")
+                .expect("just sent Ok")
+        })
     }
 
-    /// Try to send trailers on this channel.
+    /// Send trailers on this channel.
     ///
     /// # Errors
     ///
     /// Returns `Err(HeaderMap)` if the channel could not (currently) accept
     /// another `HeaderMap`.
     #[inline]
-    pub(crate) fn try_send_trailers(
-        &mut self,
-        trailers: HeaderMap,
-    ) -> Result<(), Option<HeaderMap>> {
-        let tx = match self.trailers_tx.take() {
-            Some(tx) => tx,
-            None => return Err(None),
-        };
-
-        tx.send(trailers).map_err(Some)
+    pub(crate) fn send_trailers(&mut self, trailers: HeaderMap) -> Result<(), Option<HeaderMap>> {
+        self.trailers_tx
+            .take()
+            .ok_or(None)?
+            .send(trailers)
+            .map_err(Some)
     }
 
     /// Send an error on this channel, which will cause the body stream to end with an error.
+    ///
+    /// # Panics
+    ///
+    /// If `poll_ready` was not successfully called prior to calling `send_data`, then this method
+    /// will panic.
     #[inline]
     pub(crate) fn send_error(&mut self, err: Error) {
-        // clone so the send works even if buffer is full
-        let _ = self.data_tx.clone().try_send(Err(err));
+        let _ = self.data_tx.send_item(Err(err));
     }
 }
 
@@ -295,7 +315,8 @@ mod tests {
         }
 
         #[cfg(test)]
-        pub(crate) fn abort(mut self) {
+        async fn abort(mut self) {
+            self.ready().await.expect("ready");
             self.send_error(Error::new_body_write_aborted());
         }
     }
@@ -306,7 +327,7 @@ mod tests {
         // the size by too much.
 
         let body_size = mem::size_of::<Incoming>();
-        let body_expected_size = mem::size_of::<u64>() * 5;
+        let body_expected_size = mem::size_of::<u64>() * 6;
         assert!(
             body_size <= body_expected_size,
             "Body size = {body_size} <= {body_expected_size}",
@@ -316,7 +337,7 @@ mod tests {
 
         assert_eq!(
             mem::size_of::<Sender>(),
-            mem::size_of::<usize>() * 5,
+            mem::size_of::<usize>() * 8,
             "Sender"
         );
 
@@ -350,7 +371,7 @@ mod tests {
     async fn channel_abort() {
         let (tx, mut rx) = Incoming::channel();
 
-        tx.abort();
+        tx.abort().await;
 
         let err = rx.frame().await.unwrap().unwrap_err();
         assert!(err.is_body_write_aborted(), "{err:?}");
@@ -360,9 +381,8 @@ mod tests {
     async fn channel_abort_when_buffer_is_full() {
         let (mut tx, mut rx) = Incoming::channel();
 
-        tx.try_send_data("chunk 1".into()).expect("send 1");
-        // buffer is full, but can still send abort
-        tx.abort();
+        tx.ready().await.expect("ready");
+        tx.send_data("chunk 1".into()).expect("send 1");
 
         let chunk1 = rx
             .frame()
@@ -373,25 +393,34 @@ mod tests {
             .unwrap();
         assert_eq!(chunk1, "chunk 1");
 
+        // buffer is full, but can still send abort
+        tx.ready().await.expect("ready");
+        tx.abort().await;
+
         let err = rx.frame().await.unwrap().unwrap_err();
         assert!(err.is_body_write_aborted(), "{err:?}");
     }
 
-    #[test]
-    fn channel_buffers_one() {
+    #[tokio::test]
+    async fn channel_buffers_one() {
         let (mut tx, _rx) = Incoming::channel();
 
-        tx.try_send_data("chunk 1".into()).expect("send 1");
+        tx.ready().await.expect("ready");
+        tx.send_data("chunk 1".into()).expect("send 1");
 
-        // buffer is now full
-        let chunk2 = tx.try_send_data("chunk 2".into()).expect_err("send 2");
-        assert_eq!(chunk2, "chunk 2");
+        // buffer is now full, poll_ready should not be ready
+        let res = tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            std::future::poll_fn(|cx| tx.poll_ready(cx)),
+        )
+        .await;
+
+        assert!(res.is_err(), "poll_ready unexpectedly became ready");
     }
 
     #[tokio::test]
     async fn channel_empty() {
         let (_, mut rx) = Incoming::channel();
-
         assert!(rx.frame().await.is_none());
     }
 

--- a/src/client/core/body/length.rs
+++ b/src/client/core/body/length.rs
@@ -6,7 +6,7 @@ use crate::client::core::error::Parse;
 pub(crate) struct DecodedLength(u64);
 
 impl DecodedLength {
-    const MAX_LEN: u64 = u64::MAX - 2;
+    pub(crate) const MAX_LEN: u64 = u64::MAX - 2;
     pub(crate) const CLOSE_DELIMITED: DecodedLength = DecodedLength(u64::MAX);
     pub(crate) const CHUNKED: DecodedLength = DecodedLength(u64::MAX - 1);
     pub(crate) const ZERO: DecodedLength = DecodedLength(0);
@@ -22,6 +22,7 @@ impl DecodedLength {
     }
 
     /// Converts to an `Option<u64>` representing a Known or Unknown length.
+    #[inline]
     pub(crate) fn into_opt(self) -> Option<u64> {
         match self {
             DecodedLength::CHUNKED | DecodedLength::CLOSE_DELIMITED => None,

--- a/src/client/core/body/watch.rs
+++ b/src/client/core/body/watch.rs
@@ -5,7 +5,6 @@
 //! - The value `0` is reserved for closed.
 
 use std::{
-    pin::Pin,
     sync::{
         Arc,
         atomic::{AtomicU8, Ordering},
@@ -17,19 +16,15 @@ use futures_util::task::AtomicWaker;
 
 use crate::client::core::Error;
 
-#[repr(u8)]
-#[derive(Clone, Copy, PartialEq, Eq)]
-#[must_use = "watch::Value is a bitfield, so the variants are not mutually exclusive"]
-pub(super) enum Value {
-    Pending = 1,
-    Ready = 2,
-    Closed = 0,
-}
+type Value = u8;
+const READY: Value = 2;
+const PENDING: Value = 1;
+const CLOSED: Value = 0;
 
 pub(super) fn channel(wanter: bool) -> (Sender, Receiver) {
-    let initial = if wanter { Value::Pending } else { Value::Ready };
+    let initial = if wanter { PENDING } else { READY };
     let shared = Arc::new(Shared {
-        value: AtomicU8::new(initial as _),
+        value: AtomicU8::new(initial),
         waker: AtomicWaker::new(),
     });
 
@@ -57,33 +52,35 @@ pub(super) struct Receiver {
 // ===== impl Sender =====
 
 impl Sender {
-    #[inline]
-    pub(super) fn send(&mut self, value: Value) {
-        if self.shared.value.swap(value as u8, Ordering::SeqCst) != value as u8 {
+    #[inline(always)]
+    pub(super) fn ready(&self) {
+        self.send(READY);
+    }
+
+    fn send(&self, value: Value) {
+        if self.shared.value.swap(value, Ordering::SeqCst) != value {
             self.shared.waker.wake();
         }
     }
 }
 
 impl Drop for Sender {
-    #[inline]
+    #[inline(always)]
     fn drop(&mut self) {
-        self.send(Value::Closed);
+        self.send(CLOSED);
     }
 }
 
 // ===== impl Receiver =====
 
-impl Future for Receiver {
-    type Output = Result<(), Error>;
-
-    #[inline]
-    fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
+impl Receiver {
+    #[inline(always)]
+    pub(super) fn poll_ready(&self, cx: &mut task::Context<'_>) -> Poll<Result<(), Error>> {
         self.shared.waker.register(cx.waker());
         match self.shared.value.load(Ordering::SeqCst) {
-            2 => Poll::Ready(Ok(())),
-            1 => Poll::Pending,
-            0 => Poll::Ready(Err(Error::new_closed())),
+            READY => Poll::Ready(Ok(())),
+            PENDING => Poll::Pending,
+            CLOSED => Poll::Ready(Err(Error::new_closed())),
             unexpected => unreachable!("watch value: {}", unexpected),
         }
     }

--- a/src/client/core/proto/http1/conn.rs
+++ b/src/client/core/proto/http1/conn.rs
@@ -204,7 +204,8 @@ where
             self.state.reading = Reading::KeepAlive;
             self.try_keep_alive(cx);
         } else if msg.expect_continue && msg.head.version.gt(&Version::HTTP_10) {
-            let h1_max_header_size = None; // TODO: remove this when we land h1_max_header_size support
+            // TODO: remove this when we land h1_max_header_size support
+            let h1_max_header_size = None;
             self.state.reading = Reading::Continue(Decoder::new(
                 msg.decode,
                 self.state.h1_max_headers,
@@ -212,7 +213,8 @@ where
             ));
             wants = wants.add(Wants::EXPECT);
         } else {
-            let h1_max_header_size = None; // TODO: remove this when we land h1_max_header_size support
+            // TODO: remove this when we land h1_max_header_size support
+            let h1_max_header_size = None;
             self.state.reading = Reading::Body(Decoder::new(
                 msg.decode,
                 self.state.h1_max_headers,

--- a/src/client/core/proto/http1/dispatch.rs
+++ b/src/client/core/proto/http1/dispatch.rs
@@ -91,7 +91,9 @@ where
         Poll::Ready(ready!(self.poll_inner(cx, should_shutdown)).or_else(|e| {
             // Be sure to alert a streaming body of the failure.
             if let Some(mut body) = self.body_tx.take() {
-                body.send_error(Error::new_body("connection error"));
+                if body.poll_ready(cx).is_ready() {
+                    body.send_error(Error::new_body("connection error"));
+                }
             }
             // An error means we're shutting down either way.
             // We just try to give the error to the user,
@@ -183,7 +185,7 @@ where
                         Poll::Ready(Some(Ok(frame))) => {
                             if frame.is_data() {
                                 let chunk = frame.into_data().unwrap_or_else(|_| unreachable!());
-                                match body.try_send_data(chunk) {
+                                match body.send_data(chunk) {
                                     Ok(()) => {
                                         self.body_tx = Some(body);
                                     }
@@ -197,7 +199,7 @@ where
                             } else if frame.is_trailers() {
                                 let trailers =
                                     frame.into_trailers().unwrap_or_else(|_| unreachable!());
-                                match body.try_send_trailers(trailers) {
+                                match body.send_trailers(trailers) {
                                     Ok(()) => {
                                         self.body_tx = Some(body);
                                     }
@@ -638,7 +640,10 @@ mod tests {
 
         let body = {
             let (mut tx, body) = Incoming::h1(DecodedLength::new(4), false);
-            tx.try_send_data("reee".into()).unwrap();
+            std::future::poll_fn(|cx| tx.poll_ready(cx))
+                .await
+                .expect("ready");
+            tx.send_data("reee".into()).unwrap();
             body
         };
 
@@ -668,7 +673,10 @@ mod tests {
 
         let body = {
             let (mut tx, body) = Incoming::channel();
-            tx.try_send_data("".into()).unwrap();
+            std::future::poll_fn(|cx| tx.poll_ready(cx))
+                .await
+                .expect("ready");
+            tx.send_data("".into()).unwrap();
             body
         };
 

--- a/src/client/core/proto/http2.rs
+++ b/src/client/core/proto/http2.rs
@@ -857,8 +857,8 @@ mod tests {
     use std::time::Duration;
 
     use bytes::Bytes;
-    use futures_channel::oneshot;
     use http_body_util::Full;
+    use tokio::sync::oneshot;
 
     use crate::client::core::{conn::http2::Builder, rt::TokioExecutor};
 

--- a/src/client/core/proto/http2/client.rs
+++ b/src/client/core/proto/http2/client.rs
@@ -7,15 +7,7 @@ use std::{
 };
 
 use bytes::Bytes;
-use futures_channel::{
-    mpsc,
-    mpsc::{Receiver, Sender},
-    oneshot,
-};
-use futures_util::{
-    future::{Either, FusedFuture},
-    stream::{FusedStream, Stream},
-};
+use futures_util::future::{Either, FusedFuture};
 use http::{Method, Request, Response, StatusCode};
 use http_body::Body;
 use http2::{
@@ -23,7 +15,14 @@ use http2::{
     client::{Builder, Connection, ResponseFuture, SendRequest},
 };
 use pin_project_lite::pin_project;
-use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::{
+    io::{AsyncRead, AsyncWrite},
+    sync::{
+        mpsc,
+        mpsc::{Receiver, Sender},
+        oneshot,
+    },
+};
 
 use super::{
     H2Upgraded, PipeToSendStream, SendBuf, ping,
@@ -248,7 +247,7 @@ where
             return Poll::Ready(());
         }
 
-        if !this.drop_rx.is_terminated() && Pin::new(&mut this.drop_rx).poll_next(cx).is_ready() {
+        if this.cancel_tx.is_some() && Pin::new(&mut this.drop_rx).poll_recv(cx).is_ready() {
             // mpsc has been dropped, hopefully polling
             // the connection some more should start shutdown
             // and then close.

--- a/src/client/layer/client/pool.rs
+++ b/src/client/layer/client/pool.rs
@@ -13,8 +13,8 @@ use std::{
     time::{Duration, Instant},
 };
 
-use futures_channel::oneshot;
 use lru::LruCache;
+use tokio::sync::oneshot;
 
 use super::exec::{self, Exec};
 use crate::{
@@ -314,7 +314,7 @@ impl<T: Poolable, K: Key> PoolInner<T, K> {
         let mut value = Some(value);
         if let Some(waiters) = self.waiters.get_mut(key) {
             while let Some(tx) = waiters.pop_front() {
-                if !tx.is_canceled() {
+                if !tx.is_closed() {
                     let reserved = value.take().expect("value already sent");
                     let reserved = match reserved.reserve() {
                         Reservation::Shared(to_keep, to_send) => {
@@ -437,7 +437,7 @@ impl<T, K: Eq + Hash> PoolInner<T, K> {
     fn clean_waiters(&mut self, key: &K) {
         let mut remove_waiters = false;
         if let Some(waiters) = self.waiters.get_mut(key) {
-            waiters.retain(|tx| !tx.is_canceled());
+            waiters.retain(|tx| !tx.is_closed());
             remove_waiters = waiters.is_empty();
         }
         if remove_waiters {


### PR DESCRIPTION
Performance sees a slight improvement in single-threaded scenarios, while in multi-threaded situations we use tokio-mpsc for scheduling to avoid thread starvation.The tokio runtime performs better overall than futures-channel.Although tokio-mpsc is runtime-agnostic, it cooperates with the scheduler when used with the tokio runtime to help prevent thread starvation.

https://docs.rs/tokio/latest/tokio/sync/mpsc/index.html#multiple-runtimes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Migrated internal channel and synchronization primitives to a tokio-based implementation, improving stream backpressure handling and consistency.

* **Bug Fixes**
  * Dispatcher now verifies readiness before signaling body errors; streaming send paths and abort behavior are more robust under full buffers.

* **Chores**
  * Removed a redundant direct dependency to simplify the manifest.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->