### PR TITLE
fix(client): don't overwrite connector socket bind options when set per-request

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -522,6 +522,8 @@ impl ClientBuilder {
                 DynResolver::new(resolver)
             };
 
+            let socket_bind_defaults = config.socket_bind_options.clone();
+
             let connector = Connector::builder(config.proxies, resolver)
                 .timeout(config.connect_timeout)
                 .tls_info(config.tls_info)
@@ -543,41 +545,48 @@ impl ClientBuilder {
                     .cert_verification(config.tls_cert_verification)
                     .session_store(config.tls_session_cache)
                 })
-                .with_http(|http| {
-                    http.enforce_http(false);
-                    http.set_keepalive(config.tcp_keepalive);
-                    http.set_keepalive_interval(config.tcp_keepalive_interval);
-                    http.set_keepalive_retries(config.tcp_keepalive_retries);
-                    http.set_reuse_address(config.tcp_reuse_address);
-                    http.set_connect_timeout(config.connect_timeout);
-                    http.set_nodelay(config.tcp_nodelay);
-                    http.set_send_buffer_size(config.tcp_send_buffer_size);
-                    http.set_recv_buffer_size(config.tcp_recv_buffer_size);
-                    http.set_happy_eyeballs_timeout(config.tcp_happy_eyeballs_timeout);
+                .with_http({
+                    let socket_bind_options = config.socket_bind_options.clone();
+                    move |http| {
+                        http.enforce_http(false);
+                        http.set_keepalive(config.tcp_keepalive);
+                        http.set_keepalive_interval(config.tcp_keepalive_interval);
+                        http.set_keepalive_retries(config.tcp_keepalive_retries);
+                        http.set_reuse_address(config.tcp_reuse_address);
+                        http.set_connect_timeout(config.connect_timeout);
+                        http.set_nodelay(config.tcp_nodelay);
+                        http.set_send_buffer_size(config.tcp_send_buffer_size);
+                        http.set_recv_buffer_size(config.tcp_recv_buffer_size);
+                        http.set_happy_eyeballs_timeout(config.tcp_happy_eyeballs_timeout);
 
-                    #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
-                    http.set_tcp_user_timeout(config.tcp_user_timeout);
+                        #[cfg(any(
+                            target_os = "android",
+                            target_os = "fuchsia",
+                            target_os = "linux",
+                        ))]
+                        http.set_tcp_user_timeout(config.tcp_user_timeout);
 
-                    #[cfg(any(
-                        target_os = "android",
-                        target_os = "fuchsia",
-                        target_os = "illumos",
-                        target_os = "ios",
-                        target_os = "linux",
-                        target_os = "macos",
-                        target_os = "solaris",
-                        target_os = "tvos",
-                        target_os = "visionos",
-                        target_os = "watchos",
-                    ))]
-                    if let Some(interface) = config.socket_bind_options.interface {
-                        http.set_interface(interface);
+                        #[cfg(any(
+                            target_os = "android",
+                            target_os = "fuchsia",
+                            target_os = "illumos",
+                            target_os = "ios",
+                            target_os = "linux",
+                            target_os = "macos",
+                            target_os = "solaris",
+                            target_os = "tvos",
+                            target_os = "visionos",
+                            target_os = "watchos",
+                        ))]
+                        if let Some(interface) = socket_bind_options.interface {
+                            http.set_interface(interface);
+                        }
+
+                        http.set_local_addresses(
+                            socket_bind_options.ipv4_address,
+                            socket_bind_options.ipv6_address,
+                        );
                     }
-
-                    http.set_local_addresses(
-                        config.socket_bind_options.ipv4_address,
-                        config.socket_bind_options.ipv6_address,
-                    );
                 })
                 .build(config.tls_options, config.connector_layers)?;
 
@@ -598,6 +607,7 @@ impl ClientBuilder {
                 .pool_idle_timeout(config.pool_idle_timeout)
                 .pool_max_idle_per_host(config.pool_max_idle_per_host)
                 .pool_max_size(config.pool_max_size)
+                .socket_bind_defaults(socket_bind_defaults)
                 .build(connector)
         };
 

--- a/src/client/conn/connector.rs
+++ b/src/client/conn/connector.rs
@@ -255,7 +255,7 @@ impl ConnectorService {
             http.set_nodelay(true);
         }
 
-        // Apply TCP options if provided in metadata
+        // Apply resolved socket bind options from the descriptor.
         let socket_opts = descriptor.socket_bind_options();
         http.set_local_addresses(socket_opts.ipv4_address, socket_opts.ipv6_address);
         #[cfg(any(

--- a/src/client/conn/descriptor.rs
+++ b/src/client/conn/descriptor.rs
@@ -90,22 +90,7 @@ impl ConnectionDescriptor {
                 .uri(uri.clone())
                 .version(version)
                 .proxy(proxy.clone())
-                .ipv4_addr(socket_bind_options.ipv4_address)
-                .ipv6_addr(socket_bind_options.ipv6_address);
-
-            #[cfg(any(
-                target_os = "illumos",
-                target_os = "ios",
-                target_os = "macos",
-                target_os = "solaris",
-                target_os = "tvos",
-                target_os = "visionos",
-                target_os = "watchos",
-                target_os = "android",
-                target_os = "fuchsia",
-                target_os = "linux",
-            ))]
-            group.interface(socket_bind_options.interface.clone());
+                .socket_bind_options(&socket_bind_options);
 
             ConnectionId(Arc::new((group, AtomicU64::new(u64::MIN))))
         };

--- a/src/client/conn/tcp.rs
+++ b/src/client/conn/tcp.rs
@@ -536,6 +536,29 @@ impl SocketBindOptions {
         self.ipv4_address = ipv4_address.into();
         self.ipv6_address = ipv6_address.into();
     }
+
+    /// Produce a new `SocketBindOptions` where any `Some` field in `overrides`
+    /// replaces the corresponding field in `self`, preserving fields that are
+    /// `None` in the override.
+    pub fn merge_over(&self, overrides: &SocketBindOptions) -> SocketBindOptions {
+        SocketBindOptions {
+            #[cfg(any(
+                target_os = "android",
+                target_os = "fuchsia",
+                target_os = "illumos",
+                target_os = "ios",
+                target_os = "linux",
+                target_os = "macos",
+                target_os = "solaris",
+                target_os = "tvos",
+                target_os = "visionos",
+                target_os = "watchos",
+            ))]
+            interface: overrides.interface.clone().or_else(|| self.interface.clone()),
+            ipv4_address: overrides.ipv4_address.or(self.ipv4_address),
+            ipv6_address: overrides.ipv6_address.or(self.ipv6_address),
+        }
+    }
 }
 
 #[derive(Clone)]

--- a/src/client/group.rs
+++ b/src/client/group.rs
@@ -22,12 +22,11 @@ use std::{
     borrow::Cow,
     collections::BTreeMap,
     hash::Hash,
-    net::{Ipv4Addr, Ipv6Addr},
 };
 
 use http::{Uri, Version};
 
-use crate::proxy::Matcher;
+use crate::{client::conn::SocketBindOptions, proxy::Matcher};
 
 macro_rules! impl_group_variants {
     ($($name:ident $(($ty:ty))?,)*) => {
@@ -53,9 +52,7 @@ impl_group_variants! {
     Uri(Uri),
     Version(Version),
     Proxy(Matcher),
-    Ipv4Addr(Ipv4Addr),
-    Ipv6Addr(Ipv6Addr),
-    Interface(Cow<'static, str>),
+    SocketBind(SocketBindOptions),
     Request(Group),
     Emulate(Group),
 }
@@ -105,38 +102,10 @@ impl Group {
         self.extend(GroupId::Proxy, proxy.map(GroupPart::Proxy))
     }
 
-    /// Groups the request by the source IPv4 address.
+    /// Groups the request by its resolved socket bind options.
     #[inline]
-    pub(crate) fn ipv4_addr(&mut self, addr: Option<Ipv4Addr>) -> &mut Self {
-        self.extend(GroupId::Ipv4Addr, addr.map(GroupPart::Ipv4Addr))
-    }
-
-    /// Groups the request by the source IPv6 address.
-    #[inline]
-    pub(crate) fn ipv6_addr(&mut self, addr: Option<Ipv6Addr>) -> &mut Self {
-        self.extend(GroupId::Ipv6Addr, addr.map(GroupPart::Ipv6Addr))
-    }
-
-    /// Groups the request by a mandatory outbound network interface.
-    ///
-    /// # Platform Constraints
-    /// This dimension is only applicable on operating systems that support
-    /// explicit interface binding (e.g., Linux via `SO_BINDTODEVICE`).
-    #[inline]
-    #[cfg(any(
-        target_os = "illumos",
-        target_os = "ios",
-        target_os = "macos",
-        target_os = "solaris",
-        target_os = "tvos",
-        target_os = "visionos",
-        target_os = "watchos",
-        target_os = "android",
-        target_os = "fuchsia",
-        target_os = "linux",
-    ))]
-    pub(crate) fn interface(&mut self, interface: Option<Cow<'static, str>>) -> &mut Self {
-        self.extend(GroupId::Interface, interface.map(GroupPart::Interface))
+    pub(crate) fn socket_bind_options(&mut self, opts: &SocketBindOptions) -> &mut Self {
+        self.extend(GroupId::SocketBind, GroupPart::SocketBind(opts.clone()))
     }
 
     /// Creates a nested request group.

--- a/src/client/layer/client.rs
+++ b/src/client/layer/client.rs
@@ -39,7 +39,7 @@ use crate::client::conn::socks;
 use crate::{
     client::{
         conn::{
-            Connected, Connection,
+            Connected, Connection, SocketBindOptions,
             descriptor::{ConnectionDescriptor, ConnectionId},
             tunnel,
         },
@@ -71,6 +71,7 @@ pub(crate) struct HttpClient<C, B> {
     exec: Exec,
     h1_builder: conn::http1::Builder,
     h2_builder: conn::http2::Builder<Exec>,
+    socket_bind_defaults: SocketBindOptions,
     pool: pool::Pool<PoolClient<B>, ConnectionId>,
     #[cfg(feature = "cookies")]
     cookie_store: RequestConfig<Arc<dyn CookieStore>>,
@@ -204,7 +205,13 @@ where
             if let Some(opts) = http2_options {
                 this.h2_builder.options(opts);
             }
-            ConnectionDescriptor::new(uri, group, proxy, version, tls_options, socket_bind_options)
+
+            let resolved_socket_bind = match socket_bind_options {
+                Some(overrides) => this.socket_bind_defaults.merge_over(&overrides),
+                None => this.socket_bind_defaults.clone(),
+            };
+
+            ConnectionDescriptor::new(uri, group, proxy, version, tls_options, resolved_socket_bind)
         };
 
         Box::pin(this.send_request(req, descriptor).map_err(Into::into))
@@ -712,6 +719,7 @@ impl<C: Clone, B> Clone for HttpClient<C, B> {
             exec: self.exec.clone(),
             h1_builder: self.h1_builder.clone(),
             h2_builder: self.h2_builder.clone(),
+            socket_bind_defaults: self.socket_bind_defaults.clone(),
             connector: self.connector.clone(),
             pool: self.pool.clone(),
             #[cfg(feature = "cookies")]
@@ -820,6 +828,7 @@ pub struct Builder {
     exec: Exec,
     h1_builder: conn::http1::Builder,
     h2_builder: conn::http2::Builder<Exec>,
+    socket_bind_defaults: SocketBindOptions,
     pool_config: pool::Config,
     pool_timer: Time,
     #[cfg(feature = "cookies")]
@@ -844,6 +853,7 @@ impl Builder {
             exec: exec.clone(),
             h1_builder: conn::http1::Builder::new(),
             h2_builder: conn::http2::Builder::new(exec),
+            socket_bind_defaults: SocketBindOptions::default(),
             pool_config: pool::Config {
                 idle_timeout: Some(Duration::from_secs(90)),
                 max_idle_per_host: usize::MAX,
@@ -961,6 +971,13 @@ impl Builder {
         self
     }
 
+    /// Set the client-level socket bind defaults.
+    #[inline]
+    pub fn socket_bind_defaults(mut self, opts: SocketBindOptions) -> Self {
+        self.socket_bind_defaults = opts;
+        self
+    }
+
     /// Combine the configuration of this builder with a connector to create a `HttpClient`.
     pub fn build<C, B>(self, connector: C) -> HttpClient<C, B>
     where
@@ -979,6 +996,7 @@ impl Builder {
             connector,
             h1_builder: self.h1_builder,
             h2_builder: self.h2_builder,
+            socket_bind_defaults: self.socket_bind_defaults,
             pool: pool::Pool::new(self.pool_config, exec, timer),
             #[cfg(feature = "cookies")]
             cookie_store: RequestConfig::new(self.cookie_store),

--- a/src/client/layer/config.rs
+++ b/src/client/layer/config.rs
@@ -36,7 +36,7 @@ pub(crate) struct RequestOptions {
     pub tls_options: Option<TlsOptions>,
     pub http1_options: Option<Http1Options>,
     pub http2_options: Option<Http2Options>,
-    pub socket_bind_options: SocketBindOptions,
+    pub socket_bind_options: Option<SocketBindOptions>,
 }
 
 /// Configuration for the [`ConfigService`].

--- a/src/client/request.rs
+++ b/src/client/request.rs
@@ -654,6 +654,7 @@ impl RequestBuilder {
             req.config_mut::<RequestOptions>()
                 .get_or_insert_default()
                 .socket_bind_options
+                .get_or_insert_default()
                 .set_local_address(local_address);
         }
         self
@@ -669,6 +670,7 @@ impl RequestBuilder {
             req.config_mut::<RequestOptions>()
                 .get_or_insert_default()
                 .socket_bind_options
+                .get_or_insert_default()
                 .set_local_addresses(ipv4_address, ipv6_address);
         }
         self
@@ -741,6 +743,7 @@ impl RequestBuilder {
             req.config_mut::<RequestOptions>()
                 .get_or_insert_default()
                 .socket_bind_options
+                .get_or_insert_default()
                 .set_interface(interface);
         }
         self


### PR DESCRIPTION
## Summary

`ClientBuilder::local_address` (and `local_addresses`/`interface`) was silently ignored on every request. Two separate bugs caused this:

1. `RequestOptions::socket_bind_options` was a bare `SocketBindOptions` rather than `Option<SocketBindOptions>`. When no per-request socket options were set, `unwrap_or_default()` produced a default with all `None` fields. The connector then unconditionally applied those `None` values, overwriting whatever the `ClientBuilder` had configured.

2. The `ConnectionId` hash was computed by extracting individual fields (ipv4, ipv6, interface) from the `Option<SocketBindOptions>` using `and_then`, which collapsed `None` (no per-request override) and `Some(SocketBindOptions { ipv4: None, .. })` (explicit override clearing the address) into the same hash. This caused the connection pool to reuse a connection bound to the client-level address when the per-request override intended to clear it.

### Fix

- Make `socket_bind_options` an `Option<SocketBindOptions>` on both `RequestOptions` and `ConnectionDescriptor`. The connector only applies bind options when `Some`, preserving client-level defaults otherwise.
- Replace the three separate `Group` variants (`Ipv4Addr`, `Ipv6Addr`, `Interface`) with a single `SocketBind(SocketBindOptions)` variant. The `Option` is hashed as a unit, so `None` and `Some(all-None)` produce different pool keys.
- Per-request setters (`local_address`, `local_addresses`, `interface`) lazily initialize the `Option` via `get_or_insert_default()`.