### PR TITLE
perf(http1/io): leverage `tokio_util::io` to reduce vectorized write overhead

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ multipart = ["dep:mime_guess", "dep:sync_wrapper", "sync_wrapper?/futures"]
 hickory-dns = ["dep:hickory-resolver"]
 
 # Enable streaming support.
-stream = ["tokio/fs", "dep:tokio-util", "dep:sync_wrapper", "sync_wrapper?/futures"]
+stream = ["tokio/fs", "dep:sync_wrapper", "sync_wrapper?/futures"]
 
 # Enable SOCKS/4/5 proxy support.
 socks = ["dep:tokio-socks"]
@@ -103,6 +103,7 @@ tokio = { version = "1.50.0", default-features = false, features = [
     "time",
     "rt",
 ] }
+tokio-util = { version = "0.7.18", default-features = false }
 tower = { version = "0.5.3", default-features = false, features = [
     "timeout",
     "util",
@@ -134,9 +135,6 @@ cookie = { version = "0.18", optional = true }
 
 ## tower http
 tower-http = { version = "0.6.8", default-features = false, optional = true }
-
-## tokio util
-tokio-util = { version = "0.7.18", default-features = false, optional = true }
 
 ## socks
 tokio-socks = { version = "0.5.2", optional = true }

--- a/src/client/core/body/incoming.rs
+++ b/src/client/core/body/incoming.rs
@@ -125,7 +125,6 @@ impl Body for Incoming {
         cx: &mut Context<'_>,
     ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
         match self.kind {
-            Kind::Empty => Poll::Ready(None),
             Kind::H1 {
                 content_length: ref mut len,
                 ref mut data_rx,
@@ -188,6 +187,7 @@ impl Body for Incoming {
                     Err(e) => Poll::Ready(Some(Err(Error::new_h2(e)))),
                 }
             }
+            Kind::Empty => Poll::Ready(None),
         }
     }
 

--- a/src/client/core/proto/http1/io.rs
+++ b/src/client/core/proto/http1/io.rs
@@ -255,17 +255,12 @@ where
                 return self.poll_flush_flattened(cx);
             }
 
-            const MAX_WRITEV_BUFS: usize = 64;
             loop {
-                let n = {
-                    let mut iovs = [IoSlice::new(&[]); MAX_WRITEV_BUFS];
-                    let len = self.write_buf.chunks_vectored(&mut iovs);
-                    ready!(Pin::new(&mut self.io).poll_write_vectored(cx, &iovs[..len]))?
-                };
-                // TODO(eliza): we have to do this manually because
-                // `poll_write_buf` doesn't exist in Tokio 0.3 yet...when
-                // `poll_write_buf` comes back, the manual advance will need to leave!
-                self.write_buf.advance(n);
+                let n = ready!(tokio_util::io::poll_write_buf(
+                    Pin::new(&mut self.io),
+                    cx,
+                    &mut self.write_buf,
+                )?);
                 debug!("flushed {} bytes", n);
                 if self.write_buf.remaining() == 0 {
                     break;

--- a/src/client/core/proto/http1/io.rs
+++ b/src/client/core/proto/http1/io.rs
@@ -256,6 +256,10 @@ where
             }
 
             loop {
+                // Let Tokio pick the write path.
+                // With `tokio-btls` this currently falls back to plain writes;
+                // if we later support vectored TLS writes like `tokio-rustls`,
+                // `poll_write_buf` will pick that up automatically.
                 let n = ready!(tokio_util::io::poll_write_buf(
                     Pin::new(&mut self.io),
                     cx,

--- a/src/client/core/proto/http1/io.rs
+++ b/src/client/core/proto/http1/io.rs
@@ -6,8 +6,8 @@ use std::{
     task::{Context, Poll, ready},
 };
 
-use bytes::{Buf, BufMut, Bytes, BytesMut};
-use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use bytes::{Buf, Bytes, BytesMut};
+use tokio::io::{AsyncRead, AsyncWrite};
 
 use super::{Http1Transaction, ParseContext, ParsedMessage};
 use crate::client::core::{Error, Result, common::buf::BufList};
@@ -216,22 +216,9 @@ where
             self.read_buf.reserve(next);
         }
 
-        // SAFETY: ReadBuf and poll_read promise not to set any uninitialized
-        // bytes onto `dst`.
-        #[allow(unsafe_code)]
-        let dst = unsafe { self.read_buf.chunk_mut().as_uninit_slice_mut() };
-        let mut buf = ReadBuf::uninit(dst);
-        match Pin::new(&mut self.io).poll_read(cx, &mut buf) {
-            Poll::Ready(Ok(_)) => {
-                let n = buf.filled().len();
+        match tokio_util::io::poll_read_buf(Pin::new(&mut self.io), cx, &mut self.read_buf) {
+            Poll::Ready(Ok(n)) => {
                 trace!("received {} bytes", n);
-                #[allow(unsafe_code)]
-                unsafe {
-                    // Safety: we just read that many bytes into the
-                    // uninitialized part of the buffer, so this is okay.
-                    // @tokio pls give me back `poll_read_buf` thanks
-                    self.read_buf.advance_mut(n);
-                }
                 self.read_buf_strategy.record(n);
                 Poll::Ready(Ok(n))
             }


### PR DESCRIPTION
This logic is identical to `tokio_util::io`. Since our http2 dependency already pulls in tokio_util, this won't introduce any extra overhead to the dependency tree.


```rust
/// Try to read data from an `AsyncRead` into an implementer of the [`BufMut`] trait.
///
/// [`BufMut`]: bytes::Buf
///
/// # Example
///
/// ```
/// use bytes::{Bytes, BytesMut};
/// use tokio_stream as stream;
/// use tokio::io::Result;
/// use tokio_util::io::{StreamReader, poll_read_buf};
/// use std::future::poll_fn;
/// use std::pin::Pin;
/// # #[tokio::main(flavor = "current_thread")]
/// # async fn main() -> std::io::Result<()> {
///
/// // Create a reader from an iterator. This particular reader will always be
/// // ready.
/// let mut read = StreamReader::new(stream::iter(vec![Result::Ok(Bytes::from_static(&[0, 1, 2, 3]))]));
///
/// let mut buf = BytesMut::new();
/// let mut reads = 0;
///
/// loop {
///     reads += 1;
///     let n = poll_fn(|cx| poll_read_buf(Pin::new(&mut read), cx, &mut buf)).await?;
///
///     if n == 0 {
///         break;
///     }
/// }
///
/// // one or more reads might be necessary.
/// assert!(reads >= 1);
/// assert_eq!(&buf[..], &[0, 1, 2, 3]);
/// # Ok(())
/// # }
/// ```
#[cfg_attr(not(feature = "io"), allow(unreachable_pub))]
pub fn poll_read_buf<T: AsyncRead + ?Sized, B: BufMut>(
    io: Pin<&mut T>,
    cx: &mut Context<'_>,
    buf: &mut B,
) -> Poll<io::Result<usize>> {
    if !buf.has_remaining_mut() {
        return Poll::Ready(Ok(0));
    }

    let n = {
        let dst = buf.chunk_mut();

        // Safety: `chunk_mut()` returns a `&mut UninitSlice`, and `UninitSlice` is a
        // transparent wrapper around `[MaybeUninit<u8>]`.
        let dst = unsafe { dst.as_uninit_slice_mut() };
        let mut buf = ReadBuf::uninit(dst);
        let ptr = buf.filled().as_ptr();
        ready!(io.poll_read(cx, &mut buf)?);

        // Ensure the pointer does not change from under us
        assert_eq!(ptr, buf.filled().as_ptr());
        buf.filled().len()
    };

    // Safety: This is guaranteed to be the number of initialized (and read)
    // bytes due to the invariants provided by `ReadBuf::filled`.
    unsafe {
        buf.advance_mut(n);
    }

    Poll::Ready(Ok(n))
}

/// Try to write data from an implementer of the [`Buf`] trait to an
/// [`AsyncWrite`], advancing the buffer's internal cursor.
///
/// This function will use [vectored writes] when the [`AsyncWrite`] supports
/// vectored writes.
///
/// # Examples
///
/// [`File`] implements [`AsyncWrite`] and [`Cursor<&[u8]>`] implements
/// [`Buf`]:
///
/// ```no_run
/// use tokio_util::io::poll_write_buf;
/// use tokio::io;
/// use tokio::fs::File;
///
/// use bytes::Buf;
/// use std::future::poll_fn;
/// use std::io::Cursor;
/// use std::pin::Pin;
///
/// #[tokio::main]
/// async fn main() -> io::Result<()> {
///     let mut file = File::create("foo.txt").await?;
///     let mut buf = Cursor::new(b"data to write");
///
///     // Loop until the entire contents of the buffer are written to
///     // the file.
///     while buf.has_remaining() {
///         poll_fn(|cx| poll_write_buf(Pin::new(&mut file), cx, &mut buf)).await?;
///     }
///
///     Ok(())
/// }
/// ```
///
/// [`Buf`]: bytes::Buf
/// [`AsyncWrite`]: tokio::io::AsyncWrite
/// [`File`]: tokio::fs::File
/// [vectored writes]: tokio::io::AsyncWrite::poll_write_vectored
#[cfg_attr(not(feature = "io"), allow(unreachable_pub))]
pub fn poll_write_buf<T: AsyncWrite + ?Sized, B: Buf>(
    io: Pin<&mut T>,
    cx: &mut Context<'_>,
    buf: &mut B,
) -> Poll<io::Result<usize>> {
    const MAX_BUFS: usize = 64;

    if !buf.has_remaining() {
        return Poll::Ready(Ok(0));
    }

    let n = if io.is_write_vectored() {
        let mut slices = [IoSlice::new(&[]); MAX_BUFS];
        let cnt = buf.chunks_vectored(&mut slices);
        ready!(io.poll_write_vectored(cx, &slices[..cnt]))?
    } else {
        ready!(io.poll_write(cx, buf.chunk()))?
    };

    buf.advance(n);

    Poll::Ready(Ok(n))
}

```