### PR TITLE
refactor(tls): expose certificate compression APIs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,8 +96,9 @@ smallvec = { version = "1.15.1", features = ["const_generics", "const_new"] }
 socket2 = { version = "0.6.3", features = ["all"] }
 ipnet = "2.12.0"
 lru = "0.17.0"
-btls = "0.5.5"
-tokio-btls = "0.5.5"
+btls = "0.5.6"
+btls-sys = "0.5.6"
+tokio-btls = "0.5.6"
 tokio = { version = "1.50.0", default-features = false, features = [
     "net",
     "time",

--- a/src/tls/compress.rs
+++ b/src/tls/compress.rs
@@ -6,38 +6,119 @@
 
 use std::{fmt::Debug, io};
 
-use btls::ssl;
+use btls::{
+    error::ErrorStack,
+    ssl::{self, SslConnectorBuilder},
+};
+use btls_sys as ffi;
 // Re-export the `CertificateCompressionAlgorithm` enum for users of this module.
 pub use ssl::CertificateCompressionAlgorithm;
+
+/// Certificate compression or decompression.
+///
+/// Wraps a function pointer or closure that processes certificate data.
+#[allow(clippy::type_complexity)]
+pub enum Codec {
+    /// Function pointer.
+    Pointer(fn(&[u8], &mut dyn io::Write) -> io::Result<()>),
+    /// Closure or function object.
+    Dynamic(Box<dyn Fn(&[u8], &mut dyn io::Write) -> io::Result<()> + Send + Sync>),
+}
 
 /// Trait for TLS certificate compression implementations.
 ///
 /// Provides methods for compressing and decompressing certificate data,
 /// as well as identifying the algorithm in use.
-pub trait CertificateCompressor: Debug + Send + Sync + 'static {
-    /// Perform compression of `input` buffer and write compressed data to `output`.
-    fn compress(&self, input: &[u8], output: &mut dyn io::Write) -> io::Result<()>;
+///
+/// See [RFC 8879, §3](https://www.rfc-editor.org/rfc/rfc8879.html#name-compression-algorithms)
+/// for the list of IANA-assigned compression algorithm identifiers.
+pub trait CertificateCompressor: Debug + Sync + Send + 'static {
+    /// Returns the [`Codec`] used to compress certificate chains for this algorithm.
+    fn compress(&self) -> Codec;
 
-    /// Perform decompression of `input` buffer and write compressed data to `output`.
-    fn decompress(&self, input: &[u8], output: &mut dyn io::Write) -> io::Result<()>;
+    /// Returns the [`Codec`] used to decompress certificate chains for this algorithm.
+    fn decompress(&self) -> Codec;
 
-    /// An IANA assigned identifier of compression algorithm
+    /// Returns the IANA-assigned identifier of the compression algorithm.
     fn algorithm(&self) -> CertificateCompressionAlgorithm;
 }
 
-impl ssl::CertificateCompressor for &'static dyn CertificateCompressor {
+struct Compressor<const ALGORITHM: i32> {
+    compress: Codec,
+    decompress: Codec,
+}
+
+// ===== impl Codec =====
+
+impl Codec {
     #[inline]
-    fn compress(&self, input: &[u8], output: &mut dyn io::Write) -> io::Result<()> {
-        (*self).compress(input, output)
+    fn call(&self, input: &[u8], output: &mut dyn io::Write) -> io::Result<()> {
+        match self {
+            Codec::Pointer(func) => func(input, output),
+            Codec::Dynamic(closure) => closure(input, output),
+        }
+    }
+}
+
+// ===== impl Compressor =====
+
+impl<const ALGORITHM: i32> ssl::CertificateCompressor for Compressor<ALGORITHM> {
+    const ALGORITHM: CertificateCompressionAlgorithm = match ALGORITHM {
+        ffi::TLSEXT_cert_compression_zlib => CertificateCompressionAlgorithm::ZLIB,
+        ffi::TLSEXT_cert_compression_brotli => CertificateCompressionAlgorithm::BROTLI,
+        ffi::TLSEXT_cert_compression_zstd => CertificateCompressionAlgorithm::ZSTD,
+        _ => unreachable!(),
+    };
+    const CAN_COMPRESS: bool = true;
+    const CAN_DECOMPRESS: bool = true;
+
+    #[inline]
+    fn compress<W>(&self, input: &[u8], output: &mut W) -> io::Result<()>
+    where
+        W: io::Write,
+    {
+        self.compress.call(input, output)
     }
 
     #[inline]
-    fn decompress(&self, input: &[u8], output: &mut dyn io::Write) -> io::Result<()> {
-        (*self).decompress(input, output)
+    fn decompress<W>(&self, input: &[u8], output: &mut W) -> io::Result<()>
+    where
+        W: io::Write,
+    {
+        self.decompress.call(input, output)
     }
+}
 
-    #[inline]
-    fn algorithm(&self) -> CertificateCompressionAlgorithm {
-        (*self).algorithm()
+/// Register a certificate compressor with the given [`SslConnectorBuilder`].
+pub(super) fn register(
+    compressor: &dyn CertificateCompressor,
+    builder: &mut SslConnectorBuilder,
+) -> Result<(), ErrorStack> {
+    match compressor.algorithm() {
+        CertificateCompressionAlgorithm::ZLIB => {
+            builder.add_certificate_compression_algorithm(Compressor::<
+                { ffi::TLSEXT_cert_compression_zlib },
+            > {
+                compress: compressor.compress(),
+                decompress: compressor.decompress(),
+            })
+        }
+        CertificateCompressionAlgorithm::BROTLI => {
+            builder.add_certificate_compression_algorithm(Compressor::<
+                { ffi::TLSEXT_cert_compression_brotli },
+            > {
+                compress: compressor.compress(),
+                decompress: compressor.decompress(),
+            })
+        }
+        CertificateCompressionAlgorithm::ZSTD => {
+            builder.add_certificate_compression_algorithm(Compressor::<
+                { ffi::TLSEXT_cert_compression_zstd },
+            > {
+                compress: compressor.compress(),
+                decompress: compressor.decompress(),
+            })
+        }
+        _ => unreachable!(),
     }
 }

--- a/src/tls/conn.rs
+++ b/src/tls/conn.rs
@@ -342,7 +342,7 @@ impl TlsConnectorBuilder {
             .map_err(Error::tls)?
             .set_cert_store(self.cert_store.as_ref())?
             .set_cert_verification(self.cert_verification)?
-            .set_cert_compressors(opts.certificate_compressors.as_deref())?;
+            .set_cert_compressors(opts.certificate_compressors.as_ref())?;
 
         // Set Identity
         if let Some(ref identity) = self.identity {

--- a/src/tls/conn/ext.rs
+++ b/src/tls/conn/ext.rs
@@ -1,8 +1,13 @@
+use std::borrow::Cow;
+
 use btls::ssl::{SslConnectorBuilder, SslVerifyMode};
 
 use crate::{
     Error,
-    tls::{compress::CertificateCompressor, trust::CertStore},
+    tls::{
+        compress::{self, CertificateCompressor},
+        trust::CertStore,
+    },
 };
 
 /// SslConnectorBuilderExt trait for `SslConnectorBuilder`.
@@ -16,7 +21,7 @@ pub trait SslConnectorBuilderExt {
     /// Configure the certificate compressors for the given `SslConnectorBuilder`.
     fn set_cert_compressors(
         self,
-        algs: Option<&[&'static dyn CertificateCompressor]>,
+        compressors: Option<&Cow<'static, [&'static dyn CertificateCompressor]>>,
     ) -> crate::Result<SslConnectorBuilder>;
 }
 
@@ -45,12 +50,11 @@ impl SslConnectorBuilderExt for SslConnectorBuilder {
     #[inline]
     fn set_cert_compressors(
         mut self,
-        algs: Option<&[&'static dyn CertificateCompressor]>,
+        compressors: Option<&Cow<'static, [&'static dyn CertificateCompressor]>>,
     ) -> crate::Result<SslConnectorBuilder> {
-        if let Some(algs) = algs {
-            for algorithm in algs {
-                self.add_certificate_compression_algorithm(*algorithm)
-                    .map_err(Error::tls)?;
+        if let Some(compressors) = compressors {
+            for compressor in compressors.as_ref() {
+                compress::register(*compressor, &mut self).map_err(Error::tls)?;
             }
         }
 

--- a/tests/emulate.rs
+++ b/tests/emulate.rs
@@ -3,7 +3,7 @@ use std::{
     time::Duration,
 };
 
-use brotli::{CompressorWriter as BrotliDecoder, Decompressor as BrotliEncoder};
+use brotli::{CompressorWriter as BrotliEncoder, Decompressor as BrotliDecoder};
 use flate2::{Compression, read::ZlibDecoder, write::ZlibEncoder};
 use wreq::{
     Client, Emulation,
@@ -13,13 +13,16 @@ use wreq::{
     },
     tls::{
         AlpnProtocol, ExtensionType, KeyShare, TlsOptions, TlsVersion,
-        compress::{CertificateCompressionAlgorithm, CertificateCompressor},
+        compress::{CertificateCompressionAlgorithm, CertificateCompressor, Codec},
     },
 };
 use zstd::stream::{Decoder as ZstdDecoder, Encoder as ZstdEncoder};
 
 #[derive(Debug)]
-struct BrotliCompressor;
+struct BrotliCompressor {
+    q: u32,
+    lgwin: u32,
+}
 
 #[derive(Debug)]
 struct ZlibCompressor;
@@ -28,16 +31,23 @@ struct ZlibCompressor;
 struct ZstdCompressor;
 
 impl CertificateCompressor for BrotliCompressor {
-    fn compress(&self, input: &[u8], output: &mut dyn io::Write) -> io::Result<()> {
-        let mut writer = BrotliDecoder::new(output, input.len(), 11, 22);
-        writer.write_all(input)?;
-        writer.flush()
+    fn compress(&self) -> Codec {
+        let q = self.q;
+        let lgwin = self.lgwin;
+        Codec::Dynamic(Box::new(move |input, output| {
+            let mut writer = BrotliEncoder::new(output, input.len(), q, lgwin);
+            writer.write_all(input)?;
+            writer.flush()?;
+            Ok(())
+        }))
     }
 
-    fn decompress(&self, input: &[u8], output: &mut dyn io::Write) -> io::Result<()> {
-        let mut reader = BrotliEncoder::new(input, 4096);
-        io::copy(&mut reader, output)?;
-        Ok(())
+    fn decompress(&self) -> Codec {
+        Codec::Pointer(|input, output| {
+            let mut reader = BrotliDecoder::new(input, 4096);
+            io::copy(&mut reader, output)?;
+            Ok(())
+        })
     }
 
     fn algorithm(&self) -> CertificateCompressionAlgorithm {
@@ -46,17 +56,21 @@ impl CertificateCompressor for BrotliCompressor {
 }
 
 impl CertificateCompressor for ZlibCompressor {
-    fn compress(&self, input: &[u8], output: &mut dyn io::Write) -> io::Result<()> {
-        let mut encoder = ZlibEncoder::new(output, Compression::default());
-        encoder.write_all(input)?;
-        encoder.finish()?;
-        Ok(())
+    fn compress(&self) -> Codec {
+        Codec::Pointer(|input, output| {
+            let mut encoder = ZlibEncoder::new(output, Compression::default());
+            encoder.write_all(input)?;
+            encoder.finish()?;
+            Ok(())
+        })
     }
 
-    fn decompress(&self, input: &[u8], output: &mut dyn io::Write) -> io::Result<()> {
-        let mut reader = ZlibDecoder::new(input);
-        io::copy(&mut reader, output)?;
-        Ok(())
+    fn decompress(&self) -> Codec {
+        Codec::Pointer(|input, output| {
+            let mut reader = ZlibDecoder::new(input);
+            io::copy(&mut reader, output)?;
+            Ok(())
+        })
     }
 
     fn algorithm(&self) -> CertificateCompressionAlgorithm {
@@ -65,17 +79,21 @@ impl CertificateCompressor for ZlibCompressor {
 }
 
 impl CertificateCompressor for ZstdCompressor {
-    fn compress(&self, input: &[u8], output: &mut dyn io::Write) -> io::Result<()> {
-        let mut encoder = ZstdEncoder::new(output, 0)?;
-        encoder.write_all(input)?;
-        encoder.finish()?;
-        Ok(())
+    fn compress(&self) -> Codec {
+        Codec::Pointer(|input, output| {
+            let mut encoder = ZstdEncoder::new(output, 0)?;
+            encoder.write_all(input)?;
+            encoder.finish()?;
+            Ok(())
+        })
     }
 
-    fn decompress(&self, input: &[u8], output: &mut dyn io::Write) -> io::Result<()> {
-        let mut reader = ZstdDecoder::new(input)?;
-        io::copy(&mut reader, output)?;
-        Ok(())
+    fn decompress(&self) -> Codec {
+        Codec::Pointer(|input, output| {
+            let mut reader = ZstdDecoder::new(input)?;
+            io::copy(&mut reader, output)?;
+            Ok(())
+        })
     }
 
     fn algorithm(&self) -> CertificateCompressionAlgorithm {
@@ -144,8 +162,8 @@ fn tls_options_template() -> TlsOptions {
             "ecdsa_sha1"
         ))
         .certificate_compressors(vec![
-            &BrotliCompressor as _,
             &ZlibCompressor as _,
+            &BrotliCompressor { q: 11, lgwin: 32 } as _,
             &ZstdCompressor as _,
         ])
         .alpn_protocols([AlpnProtocol::HTTP2, AlpnProtocol::HTTP1])


### PR DESCRIPTION
continue: https://github.com/0x676e67/wreq/pull/1085
from: https://github.com/0x676e67/wreq-python/issues/577

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated TLS dependencies to newer patch versions and added an explicit low-level TLS binding for aligned versions.

* **Refactor**
  * Reworked certificate compression plumbing to use codec factories and improved registration/dispatch for multiple compression algorithms.

* **Tests**
  * Updated test suite to exercise the new compression API and validate compressors (Brotli, zlib, zstd) with revised wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->