### PR TITLE
fix(http1): send error when dispatcher is dropped mid-body

### DIFF
--- a/src/client/conn/tcp.rs
+++ b/src/client/conn/tcp.rs
@@ -351,14 +351,9 @@ where
         match self.fallback {
             None => self.preferred.connect(config).await,
             Some(mut fallback) => {
-                let preferred_fut = self.preferred.connect(config);
-                futures_util::pin_mut!(preferred_fut);
-
-                let fallback_fut = fallback.remote.connect(config);
-                futures_util::pin_mut!(fallback_fut);
-
-                let fallback_delay = fallback.delay;
-                futures_util::pin_mut!(fallback_delay);
+                let preferred_fut = pin!(self.preferred.connect(config));
+                let fallback_fut = pin!(fallback.remote.connect(config));
+                let fallback_delay = pin!(fallback.delay);
 
                 let (result, future) =
                     match futures_util::future::select(preferred_fut, fallback_delay).await {

--- a/src/client/core/body/incoming.rs
+++ b/src/client/core/body/incoming.rs
@@ -68,7 +68,7 @@ impl Incoming {
     }
 
     pub(crate) fn h1(content_length: DecodedLength, wanter: bool) -> (Sender, Incoming) {
-        let (data_tx, data_rx) = mpsc::channel(1);
+        let (data_tx, data_rx) = mpsc::channel(2);
         let (trailers_tx, trailers_rx) = oneshot::channel();
         // If wanter is true, `Sender::poll_ready()` won't becoming ready
         // until the `Body` has been polled for data once.
@@ -280,14 +280,13 @@ impl Sender {
     }
 
     /// Send an error on this channel, which will cause the body stream to end with an error.
-    ///
-    /// # Panics
-    ///
-    /// If `poll_ready` was not successfully called prior to calling `send_data`, then this method
-    /// will panic.
     #[inline]
     pub(crate) fn send_error(&mut self, err: Error) {
-        let _ = self.data_tx.send_item(Err(err));
+        if !self.data_tx.abort_send() {
+            self.data_tx
+                .get_ref()
+                .map(|sender| sender.try_send(Err(err)));
+        }
     }
 }
 
@@ -309,14 +308,11 @@ mod tests {
     }
 
     impl Sender {
-        #[cfg(test)]
         async fn ready(&mut self) -> Result<()> {
             std::future::poll_fn(|cx| self.poll_ready(cx)).await
         }
 
-        #[cfg(test)]
-        async fn abort(mut self) {
-            self.ready().await.expect("ready");
+        fn abort(mut self) {
             self.send_error(Error::new_body_write_aborted());
         }
     }
@@ -371,7 +367,7 @@ mod tests {
     async fn channel_abort() {
         let (tx, mut rx) = Incoming::channel();
 
-        tx.abort().await;
+        tx.abort();
 
         let err = rx.frame().await.unwrap().unwrap_err();
         assert!(err.is_body_write_aborted(), "{err:?}");
@@ -383,6 +379,8 @@ mod tests {
 
         tx.ready().await.expect("ready");
         tx.send_data("chunk 1".into()).expect("send 1");
+        // buffer is full, but can still send abort
+        tx.abort();
 
         let chunk1 = rx
             .frame()
@@ -393,20 +391,18 @@ mod tests {
             .unwrap();
         assert_eq!(chunk1, "chunk 1");
 
-        // buffer is full, but can still send abort
-        tx.ready().await.expect("ready");
-        tx.abort().await;
-
         let err = rx.frame().await.unwrap().unwrap_err();
         assert!(err.is_body_write_aborted(), "{err:?}");
     }
 
     #[tokio::test]
-    async fn channel_buffers_one() {
+    async fn channel_buffers_two() {
         let (mut tx, _rx) = Incoming::channel();
 
         tx.ready().await.expect("ready");
         tx.send_data("chunk 1".into()).expect("send 1");
+        tx.ready().await.expect("ready");
+        tx.send_data("chunk 2".into()).expect("send 2");
 
         // buffer is now full, poll_ready should not be ready
         let res = tokio::time::timeout(

--- a/src/client/core/body/incoming.rs
+++ b/src/client/core/body/incoming.rs
@@ -282,11 +282,12 @@ impl Sender {
     /// Send an error on this channel, which will cause the body stream to end with an error.
     #[inline]
     pub(crate) fn send_error(&mut self, err: Error) {
-        if !self.data_tx.abort_send() {
-            self.data_tx
-                .get_ref()
-                .map(|sender| sender.try_send(Err(err)));
-        }
+        // Free any in-progress reservation so the buffer has room for the error,
+        // then try to deliver the error on the underlying channel.
+        let _ = self.data_tx.abort_send();
+        self.data_tx
+            .get_ref()
+            .map(|sender| sender.try_send(Err(err)));
     }
 }
 

--- a/src/client/core/error.rs
+++ b/src/client/core/error.rs
@@ -87,19 +87,14 @@ pub(super) enum User {
     Body,
     /// The user aborted writing of the outgoing body.
     BodyWriteAborted,
-
     /// User tried to send a connect request with a nonzero body
     InvalidConnectWithBody,
-
     /// Error from future of user's Service.
     Service,
-
     /// User tried polling for an upgrade that doesn't exist.
     NoUpgrade,
-
     /// User polled for an upgrade, but low-level API is not using upgrades.
     ManualUpgrade,
-
     /// The dispatch task is gone.
     DispatchGone,
 }

--- a/src/client/core/proto/http1/dispatch.rs
+++ b/src/client/core/proto/http1/dispatch.rs
@@ -24,7 +24,7 @@ use crate::client::core::{
 pub(crate) struct Dispatcher<D, Bs: Body, I, T> {
     conn: Conn<I, Bs::Data, T>,
     dispatch: D,
-    body_tx: Option<body::Sender>,
+    body_tx: SenderGuard,
     body_rx: Pin<Box<Option<Bs>>>,
     is_closing: bool,
 }
@@ -77,7 +77,7 @@ where
         Dispatcher {
             conn,
             dispatch,
-            body_tx: None,
+            body_tx: SenderGuard(None),
             body_rx: Box::pin(None),
             is_closing: false,
         }
@@ -97,9 +97,7 @@ where
         Poll::Ready(ready!(self.poll_inner(cx, should_shutdown)).or_else(|e| {
             // Be sure to alert a streaming body of the failure.
             if let Some(mut body) = self.body_tx.take() {
-                if body.poll_ready(cx).is_ready() {
-                    body.send_error(Error::new_body("connection error"));
-                }
+                body.send_error(Error::new_body("connection error"))
             }
             // An error means we're shutting down either way.
             // We just try to give the error to the user,
@@ -176,7 +174,7 @@ where
                     match body.poll_ready(cx) {
                         Poll::Ready(Ok(())) => (),
                         Poll::Pending => {
-                            self.body_tx = Some(body);
+                            self.body_tx.set(body);
                             return Poll::Pending;
                         }
                         Poll::Ready(Err(_canceled)) => {
@@ -193,7 +191,7 @@ where
                                 let chunk = frame.into_data().unwrap_or_else(|_| unreachable!());
                                 match body.send_data(chunk) {
                                     Ok(()) => {
-                                        self.body_tx = Some(body);
+                                        self.body_tx.set(body);
                                     }
                                     Err(_canceled) => {
                                         if self.conn.can_read_body() {
@@ -207,7 +205,7 @@ where
                                     frame.into_trailers().unwrap_or_else(|_| unreachable!());
                                 match body.send_trailers(trailers) {
                                     Ok(()) => {
-                                        self.body_tx = Some(body);
+                                        self.body_tx.set(body);
                                     }
                                     Err(_canceled) => {
                                         if self.conn.can_read_body() {
@@ -225,7 +223,7 @@ where
                             // just drop, the body will close automatically
                         }
                         Poll::Pending => {
-                            self.body_tx = Some(body);
+                            self.body_tx.set(body);
                             return Poll::Pending;
                         }
                         Poll::Ready(Some(Err(e))) => {
@@ -259,7 +257,7 @@ where
                     DecodedLength::ZERO => Incoming::empty(),
                     other => {
                         let (tx, rx) = Incoming::h1(other, wants.contains(Wants::EXPECT));
-                        self.body_tx = Some(tx);
+                        self.body_tx.set(tx);
                         rx
                     }
                 };
@@ -469,6 +467,37 @@ impl<T> Drop for OptGuard<'_, T> {
     fn drop(&mut self) {
         if self.1 {
             self.0.set(None);
+        }
+    }
+}
+
+// ===== impl SenderGuard =====
+
+/// A guard for the body `Sender`.
+///
+/// If the `Dispatcher` future is dropped (e.g. the runtime driving the
+/// connection is shut down) while it still owns a body `Sender`, the guard
+/// sends an incomplete-message error so the receiver sees an error instead
+/// of a silent, clean end-of-stream.
+struct SenderGuard(Option<body::Sender>);
+
+impl SenderGuard {
+    #[inline]
+    fn set(&mut self, sender: body::Sender) {
+        self.0 = Some(sender);
+    }
+
+    #[inline]
+    fn take(&mut self) -> Option<body::Sender> {
+        self.0.take()
+    }
+}
+
+impl Drop for SenderGuard {
+    #[inline]
+    fn drop(&mut self) {
+        if let Some(mut sender) = self.0.take() {
+            sender.send_error(Error::new_incomplete());
         }
     }
 }


### PR DESCRIPTION
backport: https://github.com/hyperium/hyper/commit/4e685f2359ebc460795063f9b6db373bdd6567d6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error signaling on connection shutdown so receivers observe errors instead of silent stream endings.
  * Made error delivery non-blocking and safe to call without prior readiness, preventing potential panics.

* **Refactor**
  * Reorganized internal connection and dispatch handling to enforce error delivery on drop and simplify connect fallback logic.
  * Increased internal request body buffering capacity to allow an extra queued chunk.

* **Tests**
  * Updated tests to match new buffering and non-blocking error semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->