### PR TITLE
fix(http2): reading trailers shouldn't propagate NO_ERROR from early response

### DIFF
--- a/src/client/core/body/incoming.rs
+++ b/src/client/core/body/incoming.rs
@@ -170,15 +170,14 @@ impl Body for Incoming {
                             return Poll::Ready(Some(Ok(Frame::data(bytes))));
                         }
                         Some(Err(e)) => {
-                            return match e.reason() {
-                                // These reasons should cause the body reading to stop, but not fail
-                                // it. The same logic as for `Read
-                                // for H2Upgraded` is applied here.
-                                Some(http2::Reason::NO_ERROR) | Some(http2::Reason::CANCEL) => {
-                                    Poll::Ready(None)
-                                }
-                                _ => Poll::Ready(Some(Err(Error::new_body(e)))),
-                            };
+                            if let Some(http2::Reason::NO_ERROR) = e.reason() {
+                                // As mentioned in RFC 7540 Section 8.1, a RST_STREAM with NO_ERROR
+                                // indicates an early response, and should cause the body reading
+                                // to stop, but not fail it:
+                                return Poll::Ready(None);
+                            } else {
+                                return Poll::Ready(Some(Err(Error::new_body(e))));
+                            }
                         }
                         None => {
                             // fall through to trailers
@@ -193,7 +192,16 @@ impl Body for Incoming {
                         ping.record_non_data();
                         Poll::Ready(Ok(t.map(Frame::trailers)).transpose())
                     }
-                    Err(e) => Poll::Ready(Some(Err(Error::new_h2(e)))),
+                    Err(e) => {
+                        if let Some(http2::Reason::NO_ERROR) = e.reason() {
+                            // Same as above, a RST_STREAM with NO_ERROR indicates an early
+                            // response, and should cause reading the trailers to stop, but
+                            // not fail it:
+                            Poll::Ready(None)
+                        } else {
+                            Poll::Ready(Some(Err(Error::new_h2(e))))
+                        }
+                    }
                 }
             }
             Kind::Empty => Poll::Ready(None),


### PR DESCRIPTION
backport: https://github.com/hyperium/hyper/commit/e5ad96b1c511b568f086100538586231628b1eab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP/2 stream reset error handling to correctly differentiate between graceful and error terminations. Only reset frames with no-error status are treated as non-fatal early closures; other error conditions are now properly reported as body or trailer errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->