### PR TITLE
fix(http1): fix possibly short reads when decoding a large body

### DIFF
--- a/src/client/core/proto/http1/decode.rs
+++ b/src/client/core/proto/http1/decode.rs
@@ -158,7 +158,7 @@ impl Decoder {
                 if *remaining == 0 {
                     Poll::Ready(Ok(Frame::data(Bytes::new())))
                 } else {
-                    let to_read = *remaining as usize;
+                    let to_read = usize::try_from(*remaining).unwrap_or(usize::MAX);
                     let buf = ready!(body.read_mem(cx, to_read))?;
                     let num = buf.as_ref().len() as u64;
                     if num > *remaining {
@@ -483,12 +483,7 @@ impl ChunkedState {
         trace!("Chunked read, remaining={:?}", rem);
 
         // cap remaining bytes at the max capacity of usize
-        let rem_cap = match *rem {
-            r if r > usize::MAX as u64 => usize::MAX,
-            r => r as usize,
-        };
-
-        let to_read = rem_cap;
+        let to_read = usize::try_from(*rem).unwrap_or(usize::MAX);
         let slice = ready!(rdr.read_mem(cx, to_read))?;
         let count = slice.len();
 


### PR DESCRIPTION
backport: https://github.com/hyperium/hyper/commit/aa702581260ca20ad3fb0acb53b56b79d7bfc3c4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal robustness and error handling in HTTP request processing to prevent potential issues with boundary conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->