### PR TITLE
refactor(timer): add reset to Sleep trait, remove unsafe downcasting

### DIFF
--- a/src/client/core/rt/timer.rs
+++ b/src/client/core/rt/timer.rs
@@ -1,7 +1,6 @@
 //! Provides a timer trait with timer-like functions
 
 use std::{
-    any::TypeId,
     future::Future,
     pin::Pin,
     sync::Arc,
@@ -31,14 +30,8 @@ pub trait Timer {
 
 /// A future returned by a `Timer`.
 pub trait Sleep: Send + Sync + Future<Output = ()> {
-    #[doc(hidden)]
-    /// This method is private and can not be implemented by downstream crate
-    fn __type_id(&self, _: private::Sealed) -> TypeId
-    where
-        Self: 'static,
-    {
-        TypeId::of::<Self>()
-    }
+    /// Reset the future to resolve at `new_deadline` instead.
+    fn reset(self: Pin<&mut Self>, new_deadline: Instant);
 }
 
 /// A user-provided timer to time background tasks.
@@ -46,38 +39,6 @@ pub trait Sleep: Send + Sync + Future<Output = ()> {
 pub enum Time {
     Timer(Arc<dyn Timer + Send + Sync>),
     Empty,
-}
-
-// =====impl Sleep =====
-
-impl dyn Sleep {
-    //! This is a re-implementation of downcast methods from std::any::Any
-
-    /// Check whether the type is the same as `T`
-    pub fn is<T>(&self) -> bool
-    where
-        T: Sleep + 'static,
-    {
-        self.__type_id(private::Sealed {}) == TypeId::of::<T>()
-    }
-
-    /// Downcast a pinned &mut Sleep object to its original type
-    pub fn downcast_mut_pin<T>(self: Pin<&mut Self>) -> Option<Pin<&mut T>>
-    where
-        T: Sleep + 'static,
-    {
-        if self.is::<T>() {
-            #[allow(unsafe_code)]
-            unsafe {
-                let inner = Pin::into_inner_unchecked(self);
-                Some(Pin::new_unchecked(
-                    &mut *(&mut *inner as *mut dyn Sleep as *mut T),
-                ))
-            }
-        } else {
-            None
-        }
-    }
 }
 
 // ===== impl Time =====
@@ -116,8 +77,4 @@ impl Timer for Time {
             Time::Timer(ref t) => t.reset(sleep, new_deadline),
         }
     }
-}
-
-mod private {
-    pub struct Sealed {}
 }

--- a/src/client/core/rt/tokio.rs
+++ b/src/client/core/rt/tokio.rs
@@ -52,26 +52,28 @@ impl TokioExecutor {
 // ==== impl TokioTimer =====
 
 impl Timer for TokioTimer {
+    #[inline]
     fn sleep(&self, duration: Duration) -> Pin<Box<dyn Sleep>> {
         Box::pin(TokioSleep {
             inner: tokio::time::sleep(duration),
         })
     }
 
+    #[inline]
     fn sleep_until(&self, deadline: Instant) -> Pin<Box<dyn Sleep>> {
         Box::pin(TokioSleep {
             inner: tokio::time::sleep_until(deadline.into()),
         })
     }
 
+    #[inline]
     fn now(&self) -> Instant {
         tokio::time::Instant::now().into()
     }
 
+    #[inline]
     fn reset(&self, sleep: &mut Pin<Box<dyn Sleep>>, new_deadline: Instant) {
-        if let Some(sleep) = sleep.as_mut().downcast_mut_pin::<TokioSleep>() {
-            sleep.reset(new_deadline)
-        }
+        sleep.as_mut().reset(new_deadline);
     }
 }
 
@@ -93,9 +95,7 @@ impl Future for TokioSleep {
     }
 }
 
-impl Sleep for TokioSleep {}
-
-impl TokioSleep {
+impl Sleep for TokioSleep {
     #[inline]
     fn reset(self: Pin<&mut Self>, deadline: Instant) {
         self.project().inner.as_mut().reset(deadline.into());


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Timers are more responsive and efficient via targeted performance inlining and internal optimizations.
  * Timer reset behavior simplified: timers can now be retargeted directly, yielding more reliable resets, lower complexity, and easier maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->