### PR TITLE
chore: release v6.0.0-rc.29

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wreq"
-version = "6.0.0-rc.28"
+version = "6.0.0-rc.29"
 description = "An ergonomic Rust HTTP Client with TLS fingerprint"
 keywords = ["http", "client", "websocket", "ja3", "ja4"]
 categories = ["web-programming::http-client"]

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,164 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [6.0.0-rc.29](https://github.com/0x676e67/wreq/compare/v6.0.0-rc.28...v6.0.0-rc.29) - 2026-05-02
+
+### Added
+
+- *(request)* expose Extensions for tower middleware compatibility ([#1119](https://github.com/0x676e67/wreq/pull/1119))
+- *(request)* introduce `Group` for explicit request differentiation ([#1117](https://github.com/0x676e67/wreq/pull/1117))
+- *(multipart)* use `WebKit` style boundary generation by default ([#1118](https://github.com/0x676e67/wreq/pull/1118))
+- *(ws)* expose underlying stream via `WebSocket::into_inner` ([#1114](https://github.com/0x676e67/wreq/pull/1114))
+- *(response)* allow forbidding connection recycling via `Response::forbid_recycle` ([#1110](https://github.com/0x676e67/wreq/pull/1110))
+- *(cookie)* RFC 9113 compliant cookie handling ([#1106](https://github.com/0x676e67/wreq/pull/1106))
+- *(tls)* allow pluggable TLS session cache ([#1101](https://github.com/0x676e67/wreq/pull/1101))
+- *(multipart)* add Form::set_boundary for custom boundaries ([#1094](https://github.com/0x676e67/wreq/pull/1094))
+- *(cookie)* fill missing domain/path in `get_all` from stored scope ([#1082](https://github.com/0x676e67/wreq/pull/1082))
+
+### Fixed
+
+- *(http1)* fix possibly short reads when decoding a large body ([#1157](https://github.com/0x676e67/wreq/pull/1157))
+- *(http1)* fix rare missed write wakeup on connections ([#1153](https://github.com/0x676e67/wreq/pull/1153))
+- *(http1)* send error when dispatcher is dropped mid-body ([#1155](https://github.com/0x676e67/wreq/pull/1155))
+- *(http2)* reading trailers shouldn't propagate NO_ERROR from early response ([#1156](https://github.com/0x676e67/wreq/pull/1156))
+- *(tcp)* ensure socket bind options is not accidentally cleared ([#1131](https://github.com/0x676e67/wreq/pull/1131))
+- *(http2)* cancel pipe_task and send `RST_STREAM` on response future drop ([#1116](https://github.com/0x676e67/wreq/pull/1116))
+- *(http1)* allow keep-alive for chunked requests with trailers ([#1112](https://github.com/0x676e67/wreq/pull/1112))
+- *(tcp)* restore the missing TCP nodelay setting ([#1102](https://github.com/0x676e67/wreq/pull/1102))
+- *(bench)* fix CPU sysinfo reading in benchmark ([#1080](https://github.com/0x676e67/wreq/pull/1080))
+- fix build
+- disable Nagle's algorithm to resolve HTTP/2 performance dip ([#1074](https://github.com/0x676e67/wreq/pull/1074))
+- *(http2)* prevent panic when calling to_str on non-UTF8 headers ([#1070](https://github.com/0x676e67/wreq/pull/1070))
+- fix build
+- *(rt)* support fake time in legacy client and TokioTimer ([#1064](https://github.com/0x676e67/wreq/pull/1064))
+
+### Other
+
+- *(trust)* improve unreachable branch in certificate loading ([#1167](https://github.com/0x676e67/wreq/pull/1167))
+- *(keylog)* separate TLS keylog responsibilities ([#1166](https://github.com/0x676e67/wreq/pull/1166))
+- update comments for tokio deps
+- *(conn)* separate conn responsibilities ([#1165](https://github.com/0x676e67/wreq/pull/1165))
+- fmt code ([#1164](https://github.com/0x676e67/wreq/pull/1164))
+- *(deps)* update `wreq-proto` dependency version to 0.2.1 ([#1163](https://github.com/0x676e67/wreq/pull/1163))
+- Enable git tagging in release configuration
+- Update README.md
+- rename toml
+- Rename release-plz.toml to .release-plz.toml
+- Add changelog path to release-plz configuration
+- release-plz.yml
+- *(core)* migrate core module to `wreq-proto` ([#1160](https://github.com/0x676e67/wreq/pull/1160))
+- *(timer)* implement reset for `Sleep`, drop unsafe downcast ([#1159](https://github.com/0x676e67/wreq/pull/1159))
+- *(deps)* update `lru` dependency version to 0.18.0 ([#1158](https://github.com/0x676e67/wreq/pull/1158))
+- optimal network chunk sizes with usage scenarios
+- revert
+- *(tcp)* reduce dependency on `futures-util` ([#1154](https://github.com/0x676e67/wreq/pull/1154))
+- *(deps)* update dependencies to latest versions
+- fmt
+- *(deps)* update http dependency version to 1.4.0 ([#1152](https://github.com/0x676e67/wreq/pull/1152))
+- #[inline]
+- *(deps)* update hickory-resolver requirement from 0.25 to 0.26 ([#1149](https://github.com/0x676e67/wreq/pull/1149))
+- *(deps)* reduce dependency on `futures-channel` ([#1127](https://github.com/0x676e67/wreq/pull/1127))
+- *(tls)* expose certificate compression APIs ([#1151](https://github.com/0x676e67/wreq/pull/1151))
+- move
+- fmt
+- reduce benchmark noise interference
+- Update Cargo.toml
+- *(style)* fix clippy warnings for Rust 1.95.0 ([#1147](https://github.com/0x676e67/wreq/pull/1147))
+- *(deps)* replace `serde_html_form` with `serde_urlencoded` ([#1146](https://github.com/0x676e67/wreq/pull/1146))
+- *(deps)* update lru dependency version to 0.17.0 ([#1145](https://github.com/0x676e67/wreq/pull/1145))
+- Update README.md
+- *(http1/encode)* Add `inline` annotations to Encoder methods ([#1144](https://github.com/0x676e67/wreq/pull/1144))
+- Change static to const for ALPHA_NUMERIC_ENCODING_MAP
+- Update ci.yml
+- *(cookie)* add subdomain cookie scoping tests for `Jar` ([#1143](https://github.com/0x676e67/wreq/pull/1143))
+- *(tunnel)* standardize zero-copy parsing ([#1142](https://github.com/0x676e67/wreq/pull/1142))
+- *(client)* Add 1 KB body case for benchmark
+- *(deps)* bump softprops/action-gh-release from 2 to 3 ([#1140](https://github.com/0x676e67/wreq/pull/1140))
+- *(http1/io)* leverage `tokio_util::io` to reduce vectorized write overhead ([#1141](https://github.com/0x676e67/wreq/pull/1141))
+- update
+- *(ws)* replace `force_http2` with `version` for HTTP version selection ([#1139](https://github.com/0x676e67/wreq/pull/1139))
+- *(core)* fmt import ([#1138](https://github.com/0x676e67/wreq/pull/1138))
+- *(sync)* fmt export ([#1136](https://github.com/0x676e67/wreq/pull/1136))
+- *(deps)* optional `parking_lot` support ([#1126](https://github.com/0x676e67/wreq/pull/1126))
+- *(layer)* add documentation comment
+- *(deps)* update `http2` dependency version to 0.5.16 ([#1134](https://github.com/0x676e67/wreq/pull/1134))
+- update examples
+- *(group)* fmt code ([#1133](https://github.com/0x676e67/wreq/pull/1133))
+- *(lib)* format exported http1 and http2 modules ([#1129](https://github.com/0x676e67/wreq/pull/1129))
+- *(incoming)* fmt code
+- *(bench/client)* fmt code
+- Revert "bench: fmt code"
+- *(deps)* remove implicit feature ([#1123](https://github.com/0x676e67/wreq/pull/1123))
+- *(http2)* fmt code ([#1124](https://github.com/0x676e67/wreq/pull/1124))
+- fmt code
+- *(ws)* rewrite `sec-websocket-protocol` handling ([#1121](https://github.com/0x676e67/wreq/pull/1121))
+- *(deps)* update `http2` dependency version to 0.5.15 ([#1122](https://github.com/0x676e67/wreq/pull/1122))
+- *(ws)* "feat(request): introduce `Group` for explicit request differentiation" ([#1120](https://github.com/0x676e67/wreq/pull/1120))
+- update SOCKS proxy support description in Cargo.toml
+- Add Discord badge to README
+- *(deps)* update `tokio-tungstenite` to version 0.29.0 ([#1113](https://github.com/0x676e67/wreq/pull/1113))
+- *(response)* replace chunk usage with BodyExt::frame ([#1111](https://github.com/0x676e67/wreq/pull/1111))
+- *(http2)* remove unstable APIs ([#1109](https://github.com/0x676e67/wreq/pull/1109))
+- *(conn)* Fix comment for proxy handling in `Conn`
+- Update RELEASE
+- *(conn)* optimize `ConnectionId` cloning ([#1108](https://github.com/0x676e67/wreq/pull/1108))
+- *(tcp)* prune redundant local address handling ([#1107](https://github.com/0x676e67/wreq/pull/1107))
+- fmt code
+- *(tls)* decouple TLS backend logic into sub-modules ([#1105](https://github.com/0x676e67/wreq/pull/1105))
+- *(tls)* expose certificate compression APIs ([#1085](https://github.com/0x676e67/wreq/pull/1085))
+- *(pool)* redesign emulation and pool ID strategy ([#1103](https://github.com/0x676e67/wreq/pull/1103))
+- fmt import
+- Fix cfg attribute formatting for set_tcp_user_timeout
+- *(conn)* modular connector component ([#1100](https://github.com/0x676e67/wreq/pull/1100))
+- update comments for compression support dependencies
+- *(multipart)* streamline legacy Form implementation
+- *(multipart)* Improve memory layout of `multipart::Form` ([#1095](https://github.com/0x676e67/wreq/pull/1095))
+- *(buf)* make `BufList::remaining` O(1) by caching length ([#1091](https://github.com/0x676e67/wreq/pull/1091))
+- *(deps)* bump btls from 0.5.3 to 0.5.4 ([#1090](https://github.com/0x676e67/wreq/pull/1090))
+- Update README.md
+- *(http1)* eliminate `ParserConfig` clones on the HTTP/1.1 request hot path ([#1088](https://github.com/0x676e67/wreq/pull/1088))
+- *(bench)* update mod benchmark comment
+- *(bench)* fmt code
+- *(bench)* format expected error annotations
+- Update README.md
+- *(deps)* replace `ahash` with `foldhash` in `lru` cache ([#1084](https://github.com/0x676e67/wreq/pull/1084))
+- *(deps)* migrate from `boring2` to `btls` ([#1083](https://github.com/0x676e67/wreq/pull/1083))
+- *(request)* fmt imports for request.rs file
+- Update README.md
+- add missing `TokioTimer` to http1 server builder ([#1081](https://github.com/0x676e67/wreq/pull/1081))
+- *(client)* fmt code
+- *(deps)* replace `raw-cpuid` with `sysinfo` implementation ([#1077](https://github.com/0x676e67/wreq/pull/1077))
+- *(hash)* simplify documentation for `HashMemo` creation ([#1076](https://github.com/0x676e67/wreq/pull/1076))
+- format benchmark group labels
+- improve benchmark test coverage ([#1075](https://github.com/0x676e67/wreq/pull/1075))
+- fmt
+- refactor `Cargo.toml` for clarity and organization
+- remove deprecated doc_cfg feature conditionally
+- simplify grouped benchmarks
+- *(bench)* optimize benchmark server ([#1073](https://github.com/0x676e67/wreq/pull/1073))
+- *(deps)* bump nttld/setup-ndk from 1.5.0 to 1.6.0 ([#1072](https://github.com/0x676e67/wreq/pull/1072))
+- lint core ([#1071](https://github.com/0x676e67/wreq/pull/1071))
+- include TLS-encrypted scenarios for HTTP/1 and HTTP/2
+- Add benchmarks for full and streaming bodies ([#1069](https://github.com/0x676e67/wreq/pull/1069))
+- clarify symbol conflict with OpenSSL ([#1068](https://github.com/0x676e67/wreq/pull/1068))
+- Update hash.rs
+- *(deps)* replace `schnellru` with `lru`  implementation ([#1066](https://github.com/0x676e67/wreq/pull/1066))
+- Update git-cliff changelog
+- Update CHANGELOG.md
+- Update cliff.toml
+- *(core)* clear code
+- fix clippy
+- add benchmarks for HTTP/1.1 and HTTP/2 ([#1065](https://github.com/0x676e67/wreq/pull/1065))
+- *(http2)* backport and apply hyper client's H2 configuration ([#1063](https://github.com/0x676e67/wreq/pull/1063))
+- *(response)* hint compiler to inline trivial response-handling functions ([#1062](https://github.com/0x676e67/wreq/pull/1062))
+- *(error)* hint compiler to inline trivial error-handling functions ([#1061](https://github.com/0x676e67/wreq/pull/1061))
+- *(request)* static init for common content-type header ([#1060](https://github.com/0x676e67/wreq/pull/1060))
 ## [unreleased]
 
 ### Features

--- a/src/client.rs
+++ b/src/client.rs
@@ -226,7 +226,7 @@ struct Config {
     tls_sni: bool,
     tls_verify_hostname: bool,
     tls_identity: Option<Identity>,
-    tls_cert_store: CertStore,
+    tls_cert_store: Option<CertStore>,
     tls_cert_verification: bool,
     tls_min_version: Option<TlsVersion>,
     tls_max_version: Option<TlsVersion>,
@@ -312,7 +312,7 @@ impl Client {
                 tls_sni: true,
                 tls_verify_hostname: true,
                 tls_identity: None,
-                tls_cert_store: CertStore::default(),
+                tls_cert_store: None,
                 tls_cert_verification: true,
                 tls_min_version: None,
                 tls_max_version: None,
@@ -1386,7 +1386,7 @@ impl ClientBuilder {
     /// for TLS connections. By default, the system's verify certificate store is used.
     #[inline]
     pub fn tls_cert_store(mut self, store: CertStore) -> ClientBuilder {
-        self.config.tls_cert_store = store;
+        self.config.tls_cert_store = Some(store);
         self
     }
 

--- a/src/tls/conn/ext.rs
+++ b/src/tls/conn/ext.rs
@@ -46,6 +46,24 @@ impl SslConnectorBuilderExt for SslConnectorBuilder {
         if let Some(store) = store {
             self.set_cert_store_ref(&store.0)
         } else {
+            #[cfg(feature = "webpki-roots")]
+            {
+                static LOAD_CERTS: std::sync::OnceLock<crate::Result<CertStore>> =
+                    std::sync::OnceLock::new();
+
+                if let Ok(store) = LOAD_CERTS.get_or_init(|| {
+                    CertStore::from_der_certs(webpki_root_certs::TLS_SERVER_ROOT_CERTS).map_err(
+                        |err| {
+                            warn!("Failed to load webpki root certificates: {:?}", err);
+                            err
+                        },
+                    )
+                }) {
+                    self.set_cert_store_ref(&store.0);
+                    return Ok(self);
+                }
+            }
+
             self.set_default_verify_paths().map_err(Error::tls)?;
         }
 

--- a/src/tls/trust/store.rs
+++ b/src/tls/trust/store.rs
@@ -8,14 +8,44 @@ use super::{
 };
 use crate::{Error, Result};
 
-/// A builder for constructing a `CertStore`.
+/// A builder for constructing a [`CertStore`].
 pub struct CertStoreBuilder {
     builder: Result<X509StoreBuilder>,
 }
 
-// ====== impl CertStoreBuilder ======
-
 impl CertStoreBuilder {
+    fn parse_cert<'c, C, P>(mut self, cert: C, parser: P) -> Self
+    where
+        C: Into<CertificateInput<'c>>,
+        P: Fn(&'c [u8]) -> Result<Certificate>,
+    {
+        if let Ok(ref mut builder) = self.builder {
+            let input = cert.into();
+            let result = input
+                .with_parser(parser)
+                .and_then(|cert| builder.add_cert(cert.0).map_err(Error::tls));
+
+            if let Err(err) = result {
+                self.builder = Err(err);
+            }
+        }
+        self
+    }
+
+    fn parse_certs<'c, I>(mut self, certs: I, parser: fn(&'c [u8]) -> Result<Certificate>) -> Self
+    where
+        I: IntoIterator,
+        I::Item: Into<CertificateInput<'c>>,
+    {
+        if let Ok(ref mut builder) = self.builder {
+            let certs = filter_map_certs(certs, parser);
+            if let Err(err) = process_certs(certs, builder) {
+                self.builder = Err(err);
+            }
+        }
+        self
+    }
+
     /// Adds a DER-encoded certificate to the certificate store.
     #[inline]
     pub fn add_der_cert<'c, C>(self, cert: C) -> Self
@@ -84,9 +114,9 @@ impl CertStoreBuilder {
         self
     }
 
-    /// Constructs the `CertStore`.
+    /// Constructs the [`CertStore`].
     ///
-    /// This method finalizes the builder and constructs the `CertStore`
+    /// This method finalizes the builder and constructs the [`CertStore`]
     /// containing all the added certificates.
     #[inline]
     pub fn build(self) -> Result<CertStore> {
@@ -94,40 +124,6 @@ impl CertStoreBuilder {
             .map(X509StoreBuilder::build)
             .map(Arc::new)
             .map(CertStore)
-    }
-}
-
-impl CertStoreBuilder {
-    fn parse_cert<'c, C, P>(mut self, cert: C, parser: P) -> Self
-    where
-        C: Into<CertificateInput<'c>>,
-        P: Fn(&'c [u8]) -> Result<Certificate>,
-    {
-        if let Ok(ref mut builder) = self.builder {
-            let input = cert.into();
-            let result = input
-                .with_parser(parser)
-                .and_then(|cert| builder.add_cert(cert.0).map_err(Error::tls));
-
-            if let Err(err) = result {
-                self.builder = Err(err);
-            }
-        }
-        self
-    }
-
-    fn parse_certs<'c, I>(mut self, certs: I, parser: fn(&'c [u8]) -> Result<Certificate>) -> Self
-    where
-        I: IntoIterator,
-        I::Item: Into<CertificateInput<'c>>,
-    {
-        if let Ok(ref mut builder) = self.builder {
-            let certs = filter_map_certs(certs, parser);
-            if let Err(err) = process_certs(certs, builder) {
-                self.builder = Err(err);
-            }
-        }
-        self
     }
 }
 
@@ -147,10 +143,8 @@ impl CertStoreBuilder {
 #[derive(Clone)]
 pub struct CertStore(pub(in crate::tls) Arc<X509Store>);
 
-// ====== impl CertStore ======
-
 impl CertStore {
-    /// Creates a new `CertStoreBuilder`.
+    /// Creates a new [`CertStoreBuilder`].
     #[inline]
     pub fn builder() -> CertStoreBuilder {
         CertStoreBuilder {
@@ -158,7 +152,7 @@ impl CertStore {
         }
     }
 
-    /// Creates a new `CertStore` from a collection of DER-encoded certificates.
+    /// Creates a new [`CertStore`] from a collection of DER-encoded certificates.
     #[inline]
     pub fn from_der_certs<'c, C>(certs: C) -> Result<CertStore>
     where
@@ -170,7 +164,7 @@ impl CertStore {
             .map(CertStore)
     }
 
-    /// Creates a new `CertStore` from a collection of PEM-encoded certificates.
+    /// Creates a new [`CertStore`] from a collection of PEM-encoded certificates.
     #[inline]
     pub fn from_pem_certs<'c, C>(certs: C) -> Result<CertStore>
     where
@@ -182,7 +176,7 @@ impl CertStore {
             .map(CertStore)
     }
 
-    /// Creates a new `CertStore` from a PEM-encoded certificate stack.
+    /// Creates a new [`CertStore`] from a PEM-encoded certificate stack.
     #[inline]
     pub fn from_pem_stack<C>(certs: C) -> Result<CertStore>
     where
@@ -191,28 +185,5 @@ impl CertStore {
         parse_certs_with_stack(certs, Certificate::stack_from_pem)
             .map(Arc::new)
             .map(CertStore)
-    }
-}
-
-impl Default for CertStore {
-    fn default() -> Self {
-        #[cfg(feature = "webpki-roots")]
-        static LOAD_CERTS: std::sync::LazyLock<CertStore> = std::sync::LazyLock::new(|| {
-            CertStore::builder()
-                .add_der_certs(webpki_root_certs::TLS_SERVER_ROOT_CERTS)
-                .build()
-                .expect("failed to load default cert store")
-        });
-
-        #[cfg(not(feature = "webpki-roots"))]
-        {
-            CertStore::builder()
-                .set_default_paths()
-                .build()
-                .expect("failed to load default cert store")
-        }
-
-        #[cfg(feature = "webpki-roots")]
-        LOAD_CERTS.clone()
     }
 }


### PR DESCRIPTION



## 🤖 New release

* `wreq`: 6.0.0-rc.28 -> 6.0.0-rc.29 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [6.0.0-rc.29](https://github.com/0x676e67/wreq/compare/v6.0.0-rc.28...v6.0.0-rc.29) - 2026-05-02

### Added

- *(request)* expose Extensions for tower middleware compatibility ([#1119](https://github.com/0x676e67/wreq/pull/1119))
- *(request)* introduce `Group` for explicit request differentiation ([#1117](https://github.com/0x676e67/wreq/pull/1117))
- *(multipart)* use `WebKit` style boundary generation by default ([#1118](https://github.com/0x676e67/wreq/pull/1118))
- *(ws)* expose underlying stream via `WebSocket::into_inner` ([#1114](https://github.com/0x676e67/wreq/pull/1114))
- *(response)* allow forbidding connection recycling via `Response::forbid_recycle` ([#1110](https://github.com/0x676e67/wreq/pull/1110))
- *(cookie)* RFC 9113 compliant cookie handling ([#1106](https://github.com/0x676e67/wreq/pull/1106))
- *(tls)* allow pluggable TLS session cache ([#1101](https://github.com/0x676e67/wreq/pull/1101))
- *(multipart)* add Form::set_boundary for custom boundaries ([#1094](https://github.com/0x676e67/wreq/pull/1094))
- *(cookie)* fill missing domain/path in `get_all` from stored scope ([#1082](https://github.com/0x676e67/wreq/pull/1082))

### Fixed

- *(http1)* fix possibly short reads when decoding a large body ([#1157](https://github.com/0x676e67/wreq/pull/1157))
- *(http1)* fix rare missed write wakeup on connections ([#1153](https://github.com/0x676e67/wreq/pull/1153))
- *(http1)* send error when dispatcher is dropped mid-body ([#1155](https://github.com/0x676e67/wreq/pull/1155))
- *(http2)* reading trailers shouldn't propagate NO_ERROR from early response ([#1156](https://github.com/0x676e67/wreq/pull/1156))
- *(tcp)* ensure socket bind options is not accidentally cleared ([#1131](https://github.com/0x676e67/wreq/pull/1131))
- *(http2)* cancel pipe_task and send `RST_STREAM` on response future drop ([#1116](https://github.com/0x676e67/wreq/pull/1116))
- *(http1)* allow keep-alive for chunked requests with trailers ([#1112](https://github.com/0x676e67/wreq/pull/1112))
- *(tcp)* restore the missing TCP nodelay setting ([#1102](https://github.com/0x676e67/wreq/pull/1102))
- *(bench)* fix CPU sysinfo reading in benchmark ([#1080](https://github.com/0x676e67/wreq/pull/1080))
- fix build
- disable Nagle's algorithm to resolve HTTP/2 performance dip ([#1074](https://github.com/0x676e67/wreq/pull/1074))
- *(http2)* prevent panic when calling to_str on non-UTF8 headers ([#1070](https://github.com/0x676e67/wreq/pull/1070))
- fix build
- *(rt)* support fake time in legacy client and TokioTimer ([#1064](https://github.com/0x676e67/wreq/pull/1064))

### Other

- *(trust)* improve unreachable branch in certificate loading ([#1167](https://github.com/0x676e67/wreq/pull/1167))
- *(keylog)* separate TLS keylog responsibilities ([#1166](https://github.com/0x676e67/wreq/pull/1166))
- update comments for tokio deps
- *(conn)* separate conn responsibilities ([#1165](https://github.com/0x676e67/wreq/pull/1165))
- fmt code ([#1164](https://github.com/0x676e67/wreq/pull/1164))
- *(deps)* update `wreq-proto` dependency version to 0.2.1 ([#1163](https://github.com/0x676e67/wreq/pull/1163))
- Enable git tagging in release configuration
- Update README.md
- rename toml
- Rename release-plz.toml to .release-plz.toml
- Add changelog path to release-plz configuration
- release-plz.yml
- *(core)* migrate core module to `wreq-proto` ([#1160](https://github.com/0x676e67/wreq/pull/1160))
- *(timer)* implement reset for `Sleep`, drop unsafe downcast ([#1159](https://github.com/0x676e67/wreq/pull/1159))
- *(deps)* update `lru` dependency version to 0.18.0 ([#1158](https://github.com/0x676e67/wreq/pull/1158))
- optimal network chunk sizes with usage scenarios
- revert
- *(tcp)* reduce dependency on `futures-util` ([#1154](https://github.com/0x676e67/wreq/pull/1154))
- *(deps)* update dependencies to latest versions
- fmt
- *(deps)* update http dependency version to 1.4.0 ([#1152](https://github.com/0x676e67/wreq/pull/1152))
- #[inline]
- *(deps)* update hickory-resolver requirement from 0.25 to 0.26 ([#1149](https://github.com/0x676e67/wreq/pull/1149))
- *(deps)* reduce dependency on `futures-channel` ([#1127](https://github.com/0x676e67/wreq/pull/1127))
- *(tls)* expose certificate compression APIs ([#1151](https://github.com/0x676e67/wreq/pull/1151))
- move
- fmt
- reduce benchmark noise interference
- Update Cargo.toml
- *(style)* fix clippy warnings for Rust 1.95.0 ([#1147](https://github.com/0x676e67/wreq/pull/1147))
- *(deps)* replace `serde_html_form` with `serde_urlencoded` ([#1146](https://github.com/0x676e67/wreq/pull/1146))
- *(deps)* update lru dependency version to 0.17.0 ([#1145](https://github.com/0x676e67/wreq/pull/1145))
- Update README.md
- *(http1/encode)* Add `inline` annotations to Encoder methods ([#1144](https://github.com/0x676e67/wreq/pull/1144))
- Change static to const for ALPHA_NUMERIC_ENCODING_MAP
- Update ci.yml
- *(cookie)* add subdomain cookie scoping tests for `Jar` ([#1143](https://github.com/0x676e67/wreq/pull/1143))
- *(tunnel)* standardize zero-copy parsing ([#1142](https://github.com/0x676e67/wreq/pull/1142))
- *(client)* Add 1 KB body case for benchmark
- *(deps)* bump softprops/action-gh-release from 2 to 3 ([#1140](https://github.com/0x676e67/wreq/pull/1140))
- *(http1/io)* leverage `tokio_util::io` to reduce vectorized write overhead ([#1141](https://github.com/0x676e67/wreq/pull/1141))
- update
- *(ws)* replace `force_http2` with `version` for HTTP version selection ([#1139](https://github.com/0x676e67/wreq/pull/1139))
- *(core)* fmt import ([#1138](https://github.com/0x676e67/wreq/pull/1138))
- *(sync)* fmt export ([#1136](https://github.com/0x676e67/wreq/pull/1136))
- *(deps)* optional `parking_lot` support ([#1126](https://github.com/0x676e67/wreq/pull/1126))
- *(layer)* add documentation comment
- *(deps)* update `http2` dependency version to 0.5.16 ([#1134](https://github.com/0x676e67/wreq/pull/1134))
- update examples
- *(group)* fmt code ([#1133](https://github.com/0x676e67/wreq/pull/1133))
- *(lib)* format exported http1 and http2 modules ([#1129](https://github.com/0x676e67/wreq/pull/1129))
- *(incoming)* fmt code
- *(bench/client)* fmt code
- Revert "bench: fmt code"
- *(deps)* remove implicit feature ([#1123](https://github.com/0x676e67/wreq/pull/1123))
- *(http2)* fmt code ([#1124](https://github.com/0x676e67/wreq/pull/1124))
- fmt code
- *(ws)* rewrite `sec-websocket-protocol` handling ([#1121](https://github.com/0x676e67/wreq/pull/1121))
- *(deps)* update `http2` dependency version to 0.5.15 ([#1122](https://github.com/0x676e67/wreq/pull/1122))
- *(ws)* "feat(request): introduce `Group` for explicit request differentiation" ([#1120](https://github.com/0x676e67/wreq/pull/1120))
- update SOCKS proxy support description in Cargo.toml
- Add Discord badge to README
- *(deps)* update `tokio-tungstenite` to version 0.29.0 ([#1113](https://github.com/0x676e67/wreq/pull/1113))
- *(response)* replace chunk usage with BodyExt::frame ([#1111](https://github.com/0x676e67/wreq/pull/1111))
- *(http2)* remove unstable APIs ([#1109](https://github.com/0x676e67/wreq/pull/1109))
- *(conn)* Fix comment for proxy handling in `Conn`
- Update RELEASE
- *(conn)* optimize `ConnectionId` cloning ([#1108](https://github.com/0x676e67/wreq/pull/1108))
- *(tcp)* prune redundant local address handling ([#1107](https://github.com/0x676e67/wreq/pull/1107))
- fmt code
- *(tls)* decouple TLS backend logic into sub-modules ([#1105](https://github.com/0x676e67/wreq/pull/1105))
- *(tls)* expose certificate compression APIs ([#1085](https://github.com/0x676e67/wreq/pull/1085))
- *(pool)* redesign emulation and pool ID strategy ([#1103](https://github.com/0x676e67/wreq/pull/1103))
- fmt import
- Fix cfg attribute formatting for set_tcp_user_timeout
- *(conn)* modular connector component ([#1100](https://github.com/0x676e67/wreq/pull/1100))
- update comments for compression support dependencies
- *(multipart)* streamline legacy Form implementation
- *(multipart)* Improve memory layout of `multipart::Form` ([#1095](https://github.com/0x676e67/wreq/pull/1095))
- *(buf)* make `BufList::remaining` O(1) by caching length ([#1091](https://github.com/0x676e67/wreq/pull/1091))
- *(deps)* bump btls from 0.5.3 to 0.5.4 ([#1090](https://github.com/0x676e67/wreq/pull/1090))
- Update README.md
- *(http1)* eliminate `ParserConfig` clones on the HTTP/1.1 request hot path ([#1088](https://github.com/0x676e67/wreq/pull/1088))
- *(bench)* update mod benchmark comment
- *(bench)* fmt code
- *(bench)* format expected error annotations
- Update README.md
- *(deps)* replace `ahash` with `foldhash` in `lru` cache ([#1084](https://github.com/0x676e67/wreq/pull/1084))
- *(deps)* migrate from `boring2` to `btls` ([#1083](https://github.com/0x676e67/wreq/pull/1083))
- *(request)* fmt imports for request.rs file
- Update README.md
- add missing `TokioTimer` to http1 server builder ([#1081](https://github.com/0x676e67/wreq/pull/1081))
- *(client)* fmt code
- *(deps)* replace `raw-cpuid` with `sysinfo` implementation ([#1077](https://github.com/0x676e67/wreq/pull/1077))
- *(hash)* simplify documentation for `HashMemo` creation ([#1076](https://github.com/0x676e67/wreq/pull/1076))
- format benchmark group labels
- improve benchmark test coverage ([#1075](https://github.com/0x676e67/wreq/pull/1075))
- fmt
- refactor `Cargo.toml` for clarity and organization
- remove deprecated doc_cfg feature conditionally
- simplify grouped benchmarks
- *(bench)* optimize benchmark server ([#1073](https://github.com/0x676e67/wreq/pull/1073))
- *(deps)* bump nttld/setup-ndk from 1.5.0 to 1.6.0 ([#1072](https://github.com/0x676e67/wreq/pull/1072))
- lint core ([#1071](https://github.com/0x676e67/wreq/pull/1071))
- include TLS-encrypted scenarios for HTTP/1 and HTTP/2
- Add benchmarks for full and streaming bodies ([#1069](https://github.com/0x676e67/wreq/pull/1069))
- clarify symbol conflict with OpenSSL ([#1068](https://github.com/0x676e67/wreq/pull/1068))
- Update hash.rs
- *(deps)* replace `schnellru` with `lru`  implementation ([#1066](https://github.com/0x676e67/wreq/pull/1066))
- Update git-cliff changelog
- Update CHANGELOG.md
- Update cliff.toml
- *(core)* clear code
- fix clippy
- add benchmarks for HTTP/1.1 and HTTP/2 ([#1065](https://github.com/0x676e67/wreq/pull/1065))
- *(http2)* backport and apply hyper client's H2 configuration ([#1063](https://github.com/0x676e67/wreq/pull/1063))
- *(response)* hint compiler to inline trivial response-handling functions ([#1062](https://github.com/0x676e67/wreq/pull/1062))
- *(error)* hint compiler to inline trivial error-handling functions ([#1061](https://github.com/0x676e67/wreq/pull/1061))
- *(request)* static init for common content-type header ([#1060](https://github.com/0x676e67/wreq/pull/1060))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).