### PR TITLE
 build(deps): update `wreq-proto` dependency version to 0.2.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,6 @@ parking_lot = ["dep:parking_lot", "http2/parking_lot"]
 prefix-symbols = ["btls/prefix-symbols"]
 
 [dependencies]
-percent-encoding = "2.3.2"
 url = "2.5.8"
 bytes = "1.11.1"
 http = "1.4.0"
@@ -88,6 +87,7 @@ http2 = "0.5.16"
 httparse = "1.10.1"
 http-body = "1.0.1"
 http-body-util = "0.1.3"
+percent-encoding = "2.3.2"
 pin-project-lite = "0.2.17"
 futures-util = { version = "0.3.32", default-features = false }
 socket2 = { version = "0.6.3", features = ["all"] }
@@ -106,7 +106,7 @@ tower = { version = "0.5.3", default-features = false, features = [
     "util",
     "retry",
 ] }
-wreq-proto = "0.1.0"
+wreq-proto = { version = "0.2.1", default-features = false }
 
 # Optional deps...
 

--- a/src/header.rs
+++ b/src/header.rs
@@ -137,15 +137,15 @@ impl OnPreserveHeaderCallback for OrigHeaderMap {
         std::mem::swap(headers, &mut sorted_headers);
     }
 
-    fn call_for_each(
+    fn call_visit(
         &self,
         headers: &mut HeaderMap,
-        dst: &mut dyn FnMut(&[u8], &http::HeaderValue),
+        dst: &mut dyn FnMut(&dyn AsRef<[u8]>, &http::HeaderValue),
     ) {
         // First, sort headers according to the order defined in this map
         for (name, orig_name) in self.iter() {
             for value in headers.get_all(name) {
-                dst(orig_name.as_ref(), value);
+                dst(orig_name, value);
             }
 
             headers.remove(name);
@@ -156,11 +156,11 @@ impl OnPreserveHeaderCallback for OrigHeaderMap {
         for (name, value) in headers.drain() {
             match (name, &prev_name) {
                 (Some(name), _) => {
-                    dst(name.as_ref(), &value);
+                    dst(&name, &value);
                     prev_name.replace(name.into_orig_header_name());
                 }
                 (None, Some(prev_name)) => {
-                    dst(prev_name.as_ref(), &value);
+                    dst(prev_name, &value);
                 }
                 _ => (),
             };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated underlying protocol library dependency to version 0.2.1 with optimized feature configuration.
  * Refined internal header processing implementation for improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->