### PR TITLE
perf(conn): remove duplicate ALPN negotiation configuration

### DIFF
--- a/src/conn.rs
+++ b/src/conn.rs
@@ -32,7 +32,11 @@ use tower::{
     util::{BoxCloneSyncService, BoxCloneSyncServiceLayer},
 };
 
-use crate::{dns::DynResolver, proxy::matcher::Intercept, tls::TlsInfo};
+use crate::{
+    dns::DynResolver,
+    proxy::matcher::Intercept,
+    tls::{AlpnProtocol, TlsInfo},
+};
 
 /// HTTP connector with dynamic DNS resolver.
 pub type HttpConnector = http::HttpConnector<DynResolver, TokioTcpConnector>;
@@ -228,7 +232,12 @@ where
 {
     fn connected(&self) -> Connected {
         let connected = self.stream.get_ref().connected();
-        if self.stream.ssl().selected_alpn_protocol() == Some(b"h2") {
+        if self
+            .stream
+            .ssl()
+            .selected_alpn_protocol()
+            .is_some_and(|alpn| AlpnProtocol::HTTP2.eq(alpn))
+        {
             connected.negotiated_h2()
         } else {
             connected

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -72,12 +72,6 @@ impl AlpnProtocol {
     /// Prefer HTTP/3
     pub const HTTP3: AlpnProtocol = AlpnProtocol(b"h3");
 
-    /// Create a new [`AlpnProtocol`] from a static byte slice.
-    #[inline]
-    pub const fn new(value: &'static [u8]) -> Self {
-        AlpnProtocol(value)
-    }
-
     #[inline]
     fn encode(self) -> Bytes {
         Self::encode_sequence(std::iter::once(&self))
@@ -96,6 +90,13 @@ impl AlpnProtocol {
     }
 }
 
+impl PartialEq<[u8]> for AlpnProtocol {
+    #[inline]
+    fn eq(&self, other: &[u8]) -> bool {
+        self.0 == other
+    }
+}
+
 /// A TLS ALPS protocol.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub struct AlpsProtocol(&'static [u8]);
@@ -109,6 +110,13 @@ impl AlpsProtocol {
 
     /// Prefer HTTP/3
     pub const HTTP3: AlpsProtocol = AlpsProtocol(b"h3");
+}
+
+impl PartialEq<[u8]> for AlpsProtocol {
+    #[inline]
+    fn eq(&self, other: &[u8]) -> bool {
+        self.0 == other
+    }
 }
 
 /// Builder for `[`TlsOptions`]`.

--- a/src/tls/conn.rs
+++ b/src/tls/conn.rs
@@ -161,8 +161,12 @@ impl TlsConnector {
                 Version::HTTP_2 => {
                     cfg.set_alpn_protos(&AlpnProtocol::HTTP2.encode())?;
                 }
-                // No ALPN protocol for other versions
-                _ => {}
+                Version::HTTP_3 => {
+                    cfg.set_alpn_protos(&AlpnProtocol::HTTP3.encode())?;
+                }
+                _ => {
+                    // For unknown versions, we don't set any ALPN protocols.
+                }
             }
         } else {
             // Default use the connector configuration.
@@ -505,31 +509,24 @@ impl<T> AsRef<T> for MaybeHttpsStream<T> {
     }
 }
 
+impl<T> Connection for MaybeHttpsStream<T>
+where
+    T: Connection,
+{
+    #[inline]
+    fn connected(&self) -> Connected {
+        match self {
+            MaybeHttpsStream::Http(s) => s.connected(),
+            MaybeHttpsStream::Https(s) => s.get_ref().connected(),
+        }
+    }
+}
+
 impl<T> fmt::Debug for MaybeHttpsStream<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             MaybeHttpsStream::Http(..) => f.pad("Http(..)"),
             MaybeHttpsStream::Https(..) => f.pad("Https(..)"),
-        }
-    }
-}
-
-impl<T> Connection for MaybeHttpsStream<T>
-where
-    T: Connection,
-{
-    fn connected(&self) -> Connected {
-        match self {
-            MaybeHttpsStream::Http(s) => s.connected(),
-            MaybeHttpsStream::Https(s) => {
-                let mut connected = s.get_ref().connected();
-
-                if s.ssl().selected_alpn_protocol() == Some(b"h2") {
-                    connected = connected.negotiated_h2();
-                }
-
-                connected
-            }
         }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved TLS protocol negotiation for more reliable HTTP/2 and HTTP/3 selection.
  * Simplified HTTPS connection state detection to rely on the underlying secure stream status.
  * Standardized ALPN handling for greater consistency and easier maintenance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/0x676e67/wreq/pull/1176)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->