### PR TITLE
refactor(body): decouple from runtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ multipart = ["dep:mime_guess", "dep:sync_wrapper", "sync_wrapper?/futures"]
 hickory-dns = ["dep:hickory-resolver"]
 
 # Enable streaming support.
-stream = ["tokio/fs", "dep:tokio-util", "dep:sync_wrapper", "sync_wrapper?/futures"]
+stream = ["dep:sync_wrapper", "sync_wrapper?/futures"]
 
 # Enable SOCKS/4/5 proxy support.
 socks = ["dep:tokio-socks"]
@@ -133,9 +133,6 @@ cookie = { version = "0.18", optional = true }
 
 ## tower http
 tower-http = { version = "0.6.8", default-features = false, optional = true }
-
-## tokio util
-tokio-util = { version = "0.7.18", default-features = false, optional = true }
 
 ## tokio socks
 tokio-socks = { version = "0.5.2", optional = true }

--- a/src/client/body.rs
+++ b/src/client/body.rs
@@ -7,8 +7,6 @@ use bytes::Bytes;
 use http_body::{Body as HttpBody, SizeHint};
 use http_body_util::{BodyExt, Either, Full, combinators::BoxBody};
 use pin_project_lite::pin_project;
-#[cfg(feature = "stream")]
-use {tokio::fs::File, tokio_util::io::ReaderStream};
 
 use crate::error::{BoxError, Error};
 
@@ -174,14 +172,6 @@ impl From<&'static str> for Body {
     #[inline]
     fn from(s: &'static str) -> Body {
         s.as_bytes().into()
-    }
-}
-
-#[cfg(feature = "stream")]
-impl From<File> for Body {
-    #[inline]
-    fn from(file: File) -> Body {
-        Body::wrap_stream(ReaderStream::new(file))
     }
 }
 


### PR DESCRIPTION
We don't want to be tightly coupled to runtime dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed direct support for converting file handles to streaming bodies when using the `stream` feature.

* **Refactor**
  * Updated the underlying dependencies for the `stream` feature.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/0x676e67/wreq/pull/1177)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->