### PR TITLE
feat(proxy): add Proxy::resolve_local to tunnel CONNECT to a locally-resolved IP

### DIFF
--- a/src/conn/connector.rs
+++ b/src/conn/connector.rs
@@ -7,6 +7,7 @@ use std::{
     time::Duration,
 };
 
+use http::Uri;
 use tokio_btls::SslStream;
 use tower::{
     BoxError, Service, ServiceBuilder, ServiceExt,
@@ -53,7 +54,6 @@ struct Config {
 /// Builder for `Connector`.
 pub struct ConnectorBuilder {
     config: Config,
-    #[cfg(feature = "socks")]
     resolver: DynResolver,
     http: HttpConnector,
     builder: TlsConnectorBuilder,
@@ -70,7 +70,6 @@ pub enum Connector {
 #[derive(Clone)]
 pub struct ConnectorService {
     config: Config,
-    #[cfg(feature = "socks")]
     resolver: DynResolver,
     tls: TlsConnector,
     http: HttpConnector,
@@ -139,7 +138,6 @@ impl ConnectorBuilder {
     ) -> crate::Result<Connector> {
         let mut service = ConnectorService {
             config: self.config,
-            #[cfg(feature = "socks")]
             resolver: self.resolver.clone(),
             http: self.http,
             tls: self
@@ -208,7 +206,6 @@ impl Connector {
                 tls_info: false,
                 timeout: None,
             },
-            #[cfg(feature = "socks")]
             resolver: resolver.clone(),
             http: HttpConnector::new(resolver, TcpConnector::new()),
             builder: TlsConnector::builder(),
@@ -355,6 +352,46 @@ impl ConnectorService {
         self.conn_from_stream(io, proxy)
     }
 
+    /// Resolve the destination host locally and return a URI whose authority is
+    /// the resolved IP address (port preserved). Used to pick the HTTP CONNECT
+    /// target when a proxy is configured with `resolve_local`. If the host is
+    /// already an IP literal, the original URI is returned unchanged.
+    async fn resolve_connect_dst(&self, uri: &Uri) -> Result<Uri, BoxError> {
+        use std::net::IpAddr;
+
+        use crate::dns::Name;
+
+        let host = uri
+            .host()
+            .ok_or_else(|| BoxError::from("missing destination host"))?;
+
+        // Already an IP literal (`host()` keeps the brackets for IPv6): nothing
+        // to resolve, tunnel straight to it.
+        let host_ip = host
+            .strip_prefix('[')
+            .and_then(|h| h.strip_suffix(']'))
+            .unwrap_or(host);
+        if host_ip.parse::<IpAddr>().is_ok() {
+            return Ok(uri.clone());
+        }
+
+        let port = uri.port_or_default();
+        let name = Name::new(host.into());
+        let mut addrs = self.resolver.clone().oneshot(name).await?;
+        let mut addr = addrs
+            .next()
+            .ok_or_else(|| BoxError::from(format!("no addresses found for {host}")))?;
+
+        // Use the destination port from the URI, never the resolver's (which may
+        // be synthetic or zero). `SocketAddr`'s `Display` brackets IPv6 for us.
+        addr.set_port(port);
+        let authority = addr.to_string();
+
+        let mut parts = uri.clone().into_parts();
+        parts.authority = Some(authority.parse()?);
+        Uri::from_parts(parts).map_err(Into::into)
+    }
+
     async fn connect_via_proxy(
         self,
         mut descriptor: ConnectionDescriptor,
@@ -419,6 +456,18 @@ impl ConnectorService {
                     // Build an HTTPS connector.
                     let mut connector = self.build_https_connector(is_https, &descriptor)?;
 
+                    // The CONNECT target. By default this is the original
+                    // destination (hostname and port), so the proxy performs DNS
+                    // resolution. When `resolve_local` is set, resolve the host with
+                    // our own resolver and send CONNECT to the resolved IP instead.
+                    // TLS SNI and the tunneled request keep using the original
+                    // hostname (carried by `descriptor`).
+                    let connect_dst = if proxy.resolve_local() {
+                        self.resolve_connect_dst(&uri).await?
+                    } else {
+                        uri.clone()
+                    };
+
                     // Build a tunnel connector to establish the CONNECT tunnel.
                     let tunneled = {
                         let mut tunnel =
@@ -435,7 +484,7 @@ impl ConnectorService {
                         }
 
                         // Connect to the proxy and establish the tunnel.
-                        tunnel.call(uri).await?
+                        tunnel.call(connect_dst).await?
                     };
 
                     // Wrap the established tunneled stream with TLS.

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -99,6 +99,9 @@ enum ProxyScheme {
 struct Extra {
     auth: Option<HeaderValue>,
     misc: Option<HeaderMap>,
+    /// Resolve the destination host locally and send the HTTP CONNECT request
+    /// to the resolved IP address instead of the hostname.
+    resolve_local: bool,
 }
 
 // ===== impl Proxy =====
@@ -185,6 +188,7 @@ impl Proxy {
             extra: Extra {
                 auth: None,
                 misc: None,
+                resolve_local: false,
             },
             scheme,
             no_proxy: None,
@@ -268,6 +272,41 @@ impl Proxy {
             }
         }
 
+        self
+    }
+
+    /// Resolve the destination host locally and tunnel to its IP address.
+    ///
+    /// By default an HTTP `CONNECT` tunnel is opened to the destination
+    /// *hostname* (e.g. `CONNECT example.com:443`), leaving DNS resolution to
+    /// the proxy. When this is enabled, the destination hostname is resolved by
+    /// the client's own DNS resolver (including any `resolve` overrides) and the
+    /// `CONNECT` request is sent to the resolved IP address instead
+    /// (e.g. `CONNECT 93.184.216.34:443`). The IP is used for both the
+    /// `CONNECT` request-target and the `Host` header of that `CONNECT` request;
+    /// the original port is preserved.
+    ///
+    /// The TLS SNI and tunneled HTTP request still use the original hostname,
+    /// so certificate validation and virtual hosting are unaffected. This
+    /// mirrors the `socks5://` (local DNS) versus `socks5h://` (remote DNS)
+    /// distinction, and is useful when the proxy's own DNS is unreliable,
+    /// censored, or when the hostname in the `CONNECT` line is filtered
+    /// upstream.
+    ///
+    /// Has no effect on SOCKS or Unix-socket proxies, or on plain HTTP requests.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate wreq;
+    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
+    /// let proxy = wreq::Proxy::all("http://proxy.example:8080")?.resolve_local(true);
+    /// # Ok(())
+    /// # }
+    /// # fn main() {}
+    /// ```
+    pub fn resolve_local(mut self, enabled: bool) -> Proxy {
+        self.extra.resolve_local = enabled;
         self
     }
 
@@ -389,6 +428,7 @@ impl Matcher {
 impl Hash for Extra {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.auth.hash(state);
+        self.resolve_local.hash(state);
         if let Some(ref misc) = self.misc {
             for (k, v) in misc.iter() {
                 k.as_str().hash(state);
@@ -478,6 +518,17 @@ mod tests {
         let got = intercept(&p, &uri("http://anywhere.local"));
         let auth = got.basic_auth().unwrap();
         assert_eq!(auth, "testme");
+    }
+
+    #[test]
+    fn test_resolve_local() {
+        let p = Proxy::all("http://example.domain/")
+            .unwrap()
+            .resolve_local(true)
+            .into_matcher();
+
+        let got = intercept(&p, &uri("https://anywhere.local"));
+        assert!(got.resolve_local());
     }
 
     #[test]

--- a/src/proxy/matcher.rs
+++ b/src/proxy/matcher.rs
@@ -165,6 +165,11 @@ impl Intercept {
         self.extra.misc.as_ref()
     }
 
+    #[inline]
+    pub(crate) fn resolve_local(&self) -> bool {
+        self.extra.resolve_local
+    }
+
     #[cfg(feature = "socks")]
     pub(crate) fn raw_auth(&self) -> Option<(Bytes, Bytes)> {
         if let Auth::Raw(ref u, ref p) = self.auth {

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -1,5 +1,5 @@
 mod support;
-use std::{env, sync::LazyLock};
+use std::{env, net::SocketAddr, sync::LazyLock};
 
 use support::server;
 use tokio::sync::Mutex;
@@ -399,6 +399,108 @@ async fn tunnel_includes_user_agent() {
         err.contains("unsuccessful"),
         "tunnel unsuccessful expected, got: {err:?}"
     );
+}
+
+/// A mock proxy that asserts the `CONNECT` request-target (and its `Host`
+/// header) equal `expected_target`, then refuses the tunnel with `400` so the
+/// client fails fast without any real TLS handshake.
+fn connect_capturing_proxy(expected_target: &'static str) -> server::Server {
+    server::http(move |req| {
+        assert_eq!(req.method(), "CONNECT");
+        assert_eq!(req.uri(), expected_target);
+        assert_eq!(req.headers()["host"], expected_target);
+
+        async {
+            let mut res = http::Response::default();
+            *res.status_mut() = http::StatusCode::BAD_REQUEST;
+            res
+        }
+    })
+}
+
+/// Asserts the request failed while establishing the proxy tunnel (the `400`
+/// returned by [`connect_capturing_proxy`]).
+fn assert_tunnel_unsuccessful(err: wreq::Error) {
+    let err = support::error::inspect(err).pop().unwrap();
+    assert!(
+        err.contains("unsuccessful"),
+        "tunnel unsuccessful expected, got: {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn tunnel_resolve_local_uses_resolved_connect_target() {
+    let server = connect_capturing_proxy("127.0.0.1:443");
+    let proxy = format!("http://{}", server.addr());
+
+    let err = Client::builder()
+        .resolve("hyper.rs.local", SocketAddr::from(([127, 0, 0, 1], 0)))
+        .proxy(wreq::Proxy::https(&proxy).unwrap().resolve_local(true))
+        .build()
+        .unwrap()
+        .get("https://hyper.rs.local/prox")
+        .send()
+        .await
+        .unwrap_err();
+
+    assert_tunnel_unsuccessful(err);
+}
+
+#[tokio::test]
+async fn tunnel_without_resolve_local_keeps_hostname_connect_target() {
+    // Even with a DNS override present, the default (opt-out) behaviour must
+    // leave the CONNECT target as the hostname: the override is ignored here.
+    let server = connect_capturing_proxy("hyper.rs.local:443");
+    let proxy = format!("http://{}", server.addr());
+
+    let err = Client::builder()
+        .resolve("hyper.rs.local", SocketAddr::from(([127, 0, 0, 1], 0)))
+        .proxy(wreq::Proxy::https(&proxy).unwrap())
+        .build()
+        .unwrap()
+        .get("https://hyper.rs.local/prox")
+        .send()
+        .await
+        .unwrap_err();
+
+    assert_tunnel_unsuccessful(err);
+}
+
+#[tokio::test]
+async fn tunnel_resolve_local_preserves_explicit_port() {
+    // The CONNECT target uses the resolved IP but keeps the URI's explicit port,
+    // not the (zero) port of the resolved address.
+    let server = connect_capturing_proxy("127.0.0.1:8443");
+    let proxy = format!("http://{}", server.addr());
+
+    let err = Client::builder()
+        .resolve("hyper.rs.local", SocketAddr::from(([127, 0, 0, 1], 0)))
+        .proxy(wreq::Proxy::https(&proxy).unwrap().resolve_local(true))
+        .build()
+        .unwrap()
+        .get("https://hyper.rs.local:8443/prox")
+        .send()
+        .await
+        .unwrap_err();
+
+    assert_tunnel_unsuccessful(err);
+}
+
+#[tokio::test]
+async fn tunnel_resolve_local_keeps_ip_literal_connect_target() {
+    let server = connect_capturing_proxy("[::1]:443");
+    let proxy = format!("http://{}", server.addr());
+
+    let err = Client::builder()
+        .proxy(wreq::Proxy::https(&proxy).unwrap().resolve_local(true))
+        .build()
+        .unwrap()
+        .get("https://[::1]/prox")
+        .send()
+        .await
+        .unwrap_err();
+
+    assert_tunnel_unsuccessful(err);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Adds an opt-in `Proxy::resolve_local(bool)` for HTTP(S) proxies.

By default, an HTTPS request through an HTTP proxy opens the tunnel with the
destination **hostname** (`CONNECT example.com:443`), leaving DNS resolution to
the proxy. When `resolve_local(true)` is set, the destination host is resolved
by the **client's own resolver** (honoring `ClientBuilder::resolve` /
`resolve_to_addrs` overrides) and the `CONNECT` request is sent to the resolved
**IP** instead (`CONNECT 93.184.216.34:443`). The IP is used for both the
`CONNECT` request-target and that request's `Host` header; the original port is
preserved.

The TLS SNI and the tunneled HTTP request keep using the original hostname, so
certificate validation and virtual hosting are unaffected.

## Motivation

This mirrors the existing `socks5://` (local DNS) vs `socks5h://` (remote DNS)
distinction, but for HTTP(S) proxies, which currently have no equivalent. It is
useful when the proxy's own DNS is unreliable or when the hostname in the
`CONNECT` line is filtered upstream — resolving locally and tunneling to the IP
sidesteps both, while the connection pool still keys on the original hostname.

## Behavior / scope

- Opt-in; default behavior is unchanged (CONNECT still uses the hostname).
- Applies only to HTTPS tunneled through an HTTP(S) proxy. No effect on SOCKS or
  Unix-socket proxies, or on plain HTTP requests.
- IP-literal destinations (incl. IPv6, e.g. `[::1]`) are passed through unchanged.
- The destination port always comes from the URI, never from the resolved
  `SocketAddr` (a custom resolver may return a synthetic/zero port).

## Tests

`tests/proxy.rs` covers: hostname → resolved IP in CONNECT; opt-out leaves the
hostname even with a `resolve` override present; explicit non-default port is
preserved; IPv6 literal passthrough. `cargo fmt`, `cargo check` (with and
without `socks`), clippy and the proxy suite all pass.

## Implementation note

The `resolver` field on the connector was previously gated behind the `socks`
feature; it is now always present, since the HTTP tunnel path also needs it.
