### PR TITLE
feat: add preconfigured_tls for SSL_CTX sharing across Client instances

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -221,6 +221,7 @@ struct Config {
     tls_max_version: Option<TlsVersion>,
     tls_session_cache: Option<Arc<dyn TlsSessionCache>>,
     tls_options: Option<TlsOptions>,
+    preconfigured_tls: Option<crate::tls::TlsConnector>,
     http1_options: Option<Http1Options>,
     http2_options: Option<Http2Options>,
     timer: Timer,
@@ -309,6 +310,7 @@ impl Client {
                 tls_max_version: None,
                 tls_session_cache: None,
                 tls_options: None,
+                preconfigured_tls: None,
                 timer: Timer::default(),
                 executor: Executor::default(),
             },
@@ -502,12 +504,18 @@ impl ClientBuilder {
                 DynResolver::new(resolver)
             };
 
-            let connector = Connector::builder(config.proxies, resolver)
+            let mut connector_builder = Connector::builder(config.proxies, resolver)
                 .timeout(config.connect_timeout)
                 .tls_info(config.tls_info)
                 .tcp_nodelay(config.tcp_nodelay)
-                .verbose(config.connection_verbose)
-                .with_tls(|tls| {
+                .verbose(config.connection_verbose);
+
+            // If a preconfigured TlsConnector was provided, use it directly.
+            // Otherwise, build one from individual TLS config options.
+            if let Some(preconfigured) = config.preconfigured_tls.take() {
+                connector_builder = connector_builder.preconfigured_tls(preconfigured);
+            } else {
+                connector_builder = connector_builder.with_tls(|tls| {
                     tls.alpn_protocol(match config.http_version_pref {
                         HttpVersionPref::Http1 => Some(AlpnProtocol::HTTP1),
                         HttpVersionPref::Http2 => Some(AlpnProtocol::HTTP2),
@@ -522,7 +530,10 @@ impl ClientBuilder {
                     .verify_hostname(config.tls_verify_hostname)
                     .cert_verification(config.tls_cert_verification)
                     .session_store(config.tls_session_cache)
-                })
+                });
+            }
+
+            let connector = connector_builder
                 .with_http(|http| {
                     http.enforce_http(false);
                     http.set_keepalive(config.tcp_keepalive);
@@ -1494,6 +1505,51 @@ impl ClientBuilder {
         T: Into<Option<TlsOptions>>,
     {
         self.config.tls_options = options.into();
+        self
+    }
+
+    /// Use a pre-built [`TlsConnector`], allowing `SSL_CTX` reuse across multiple
+    /// `Client` instances.
+    ///
+    /// When set, the connector is used directly instead of building a new one from
+    /// individual TLS config options (`tls_sni`, `tls_identity`, `tls_cert_store`, etc.).
+    /// This avoids redundant `SSL_CTX` allocations when many clients share the same
+    /// emulation profile.
+    ///
+    /// `TlsConnector` is cheaply cloneable — its internal `SslConnector` uses
+    /// reference counting (`SSL_CTX_up_ref`), so the underlying BoringSSL `SSL_CTX`
+    /// is shared across all clones.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use wreq::tls::TlsConnector;
+    /// use wreq::Client;
+    ///
+    /// // Build one TlsConnector per emulation profile
+    /// let connector = TlsConnector::builder()
+    ///     .emulation(wreq_util::EmulationOption::builder()
+    ///         .emulation(wreq_util::Emulation::Chrome145)
+    ///         .build())
+    ///     .build()
+    ///     .unwrap();
+    ///
+    /// // Share it across multiple clients
+    /// let client_a = Client::builder()
+    ///     .preconfigured_tls(connector.clone())
+    ///     .proxy(wreq::Proxy::all("socks5h://user1:pass1@host:port").unwrap())
+    ///     .build()
+    ///     .unwrap();
+    ///
+    /// let client_b = Client::builder()
+    ///     .preconfigured_tls(connector.clone())
+    ///     .proxy(wreq::Proxy::all("socks5h://user2:pass2@host:port").unwrap())
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    #[inline]
+    pub fn preconfigured_tls(mut self, connector: crate::tls::TlsConnector) -> ClientBuilder {
+        self.config.preconfigured_tls = Some(connector);
         self
     }
 

--- a/src/conn/connector.rs
+++ b/src/conn/connector.rs
@@ -57,6 +57,7 @@ pub struct ConnectorBuilder {
     resolver: DynResolver,
     http: HttpConnector,
     builder: TlsConnectorBuilder,
+    preconfigured_tls: Option<TlsConnector>,
 }
 
 /// Connector service that establishes connections.
@@ -97,6 +98,17 @@ impl ConnectorBuilder {
         F: FnOnce(TlsConnectorBuilder) -> TlsConnectorBuilder,
     {
         self.builder = call(self.builder);
+        self
+    }
+
+    /// Use a pre-built `TlsConnector` instead of building one from `TlsConnectorBuilder`.
+    ///
+    /// When set, [`build`](Self::build) will use this connector directly,
+    /// skipping the `TlsConnectorBuilder::build()` call. The `TlsConnector` is
+    /// cheaply cloneable (BoringSSL `SSL_CTX` is reference-counted).
+    #[inline]
+    pub fn preconfigured_tls(mut self, connector: TlsConnector) -> ConnectorBuilder {
+        self.preconfigured_tls = Some(connector);
         self
     }
 
@@ -142,9 +154,12 @@ impl ConnectorBuilder {
             #[cfg(feature = "socks")]
             resolver: self.resolver.clone(),
             http: self.http,
-            tls: self
-                .builder
-                .build(tls_options.map(Cow::Owned).unwrap_or_default())?,
+            tls: match self.preconfigured_tls {
+                Some(connector) => connector,
+                None => self
+                    .builder
+                    .build(tls_options.map(Cow::Owned).unwrap_or_default())?,
+            },
             builder: Arc::new(self.builder),
         };
 
@@ -212,6 +227,7 @@ impl Connector {
             resolver: resolver.clone(),
             http: HttpConnector::new(resolver, TcpConnector::new()),
             builder: TlsConnector::builder(),
+            preconfigured_tls: None,
         }
     }
 }

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -9,6 +9,8 @@ pub mod keylog;
 pub mod session;
 pub mod trust;
 
+pub use conn::TlsConnector;
+
 use std::borrow::Cow;
 
 /// Re-exports of TLS-related types from `btls` for public use.

--- a/src/tls/conn.rs
+++ b/src/tls/conn.rs
@@ -126,6 +126,16 @@ impl TlsConnector {
         }
     }
 
+    /// Build a [`TlsConnector`] from [`TlsOptions`] (e.g. from an emulation profile).
+    ///
+    /// This is a convenience method that creates a default [`TlsConnectorBuilder`]
+    /// and applies the given `TlsOptions`. Use this when you need a standalone
+    /// `TlsConnector` to share across multiple `Client` instances via
+    /// [`ClientBuilder::preconfigured_tls`](crate::ClientBuilder::preconfigured_tls).
+    pub fn from_tls_options(opts: TlsOptions) -> crate::Result<Self> {
+        Self::builder().build(Cow::Owned(opts))
+    }
+
     fn setup_ssl(&self, uri: Uri) -> Result<Ssl, BoxError> {
         let cfg = self.ssl.configure()?;
         let host = uri.host().ok_or("URI missing host")?;


### PR DESCRIPTION
## Summary

Add `ClientBuilder::preconfigured_tls(TlsConnector)` to allow `SSL_CTX` reuse across multiple `Client` instances.

## Problem

Each `Client::builder().emulation(...).build()` creates a new BoringSSL `SSL_CTX` — the heaviest object per client at ~200 KB. It holds the full cipher suite configuration, certificate store, Chrome emulation fingerprint (extension ordering, GREASE, ALPS, etc.), and TLS session cache.

When many `Client` instances share the same emulation profile but differ in per-request config (e.g. different SOCKS5 proxy credentials), each one redundantly creates an identical `SSL_CTX`. With dozens of clients this wastes tens of MB of RSS and prevents TLS session resumption across clients.

## Solution

`TlsConnector` (wrapper around BoringSSL `SslConnector`) is cheaply cloneable — `SslContext::clone()` calls `SSL_CTX_up_ref()`, a reference-counted shallow copy. Two hundred `.clone()`s cost virtually nothing.

```rust
// Build one TlsConnector per emulation profile
let connector = wreq::tls::TlsConnector::from_tls_options(
    emulation.tls_options.unwrap_or_default()
)?;

// Share it across multiple clients
let client_a = wreq::Client::builder()
    .preconfigured_tls(connector.clone())
    .proxy(wreq::Proxy::all("socks5h://user1:pass1@host:port")?)
    .build()?;

let client_b = wreq::Client::builder()
    .preconfigured_tls(connector.clone())
    .proxy(wreq::Proxy::all("socks5h://user2:pass2@host:port")?)
    .build()?;
```

Changes
- ClientBuilder::preconfigured_tls(connector) — new method
- ConnectorBuilder::preconfigured_tls(connector) — internal plumbing
- TlsConnector::from_tls_options(opts) — convenience method
- wreq::tls::TlsConnector — public re-export

Impact
- Memory: ~200 KB saved per shared SSL_CTX. With 60+ clients sharing 5 profiles: ~11 MB reduction.
- CPU: Avoids repeated SSL_CTX_new() + Chrome emulation configuration.
- TLS performance: Shared session cache enables TLS resumption even when clients are rebuilt.
- Breaking changes: None — purely additive.