### PR TITLE
feat(client): add on_informational to RequestBuilder

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,5 +1,6 @@
 pub(super) mod body;
 pub(super) mod emulate;
+pub(super) mod expect_continue;
 pub(super) mod future;
 pub(super) mod layer;
 pub(super) mod request;

--- a/src/client/expect_continue.rs
+++ b/src/client/expect_continue.rs
@@ -1,0 +1,120 @@
+use std::{
+    pin::Pin,
+    sync::{Arc, Mutex},
+    task::{Context, Poll, Waker},
+    time::Duration,
+};
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use bytes::Bytes;
+use http_body::{Body as HttpBody, Frame, SizeHint};
+use pin_project_lite::pin_project;
+
+use crate::error::BoxError;
+
+pub(crate) struct ExpectContinueState {
+    signalled: AtomicBool,
+    waker: Mutex<Option<Waker>>,
+}
+
+impl ExpectContinueState {
+    pub(crate) fn new() -> Arc<Self> {
+        Arc::new(ExpectContinueState {
+            signalled: AtomicBool::new(false),
+            waker: Mutex::new(None),
+        })
+    }
+
+    pub(crate) fn signal(&self) {
+        self.signalled.store(true, Ordering::SeqCst);
+        if let Some(waker) = self.waker.lock().unwrap().take() {
+            waker.wake();
+        }
+    }
+
+    fn is_signalled(&self) -> bool {
+        self.signalled.load(Ordering::SeqCst)
+    }
+
+    fn store_waker(&self, waker: Waker) {
+        *self.waker.lock().unwrap() = Some(waker);
+    }
+}
+
+pin_project! {
+    /// A body wrapper that delays sending until a 100 Continue response
+    /// is received or a timeout elapses.
+    pub(crate) struct ExpectContinueBody {
+        #[pin]
+        inner: Option<crate::Body>,
+        state: Arc<ExpectContinueState>,
+        #[pin]
+        sleep: Option<tokio::time::Sleep>,
+        done: bool,
+    }
+}
+
+impl ExpectContinueBody {
+    pub(crate) fn new(
+        inner: crate::Body,
+        state: Arc<ExpectContinueState>,
+        timeout: Duration,
+    ) -> Self {
+        ExpectContinueBody {
+            inner: Some(inner),
+            state,
+            sleep: Some(tokio::time::sleep(timeout)),
+            done: false,
+        }
+    }
+}
+
+impl HttpBody for ExpectContinueBody {
+    type Data = Bytes;
+    type Error = BoxError;
+
+    fn poll_frame(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        let this = self.project();
+
+        if !*this.done {
+            if this.state.is_signalled() {
+                *this.done = true;
+                this.sleep.set(None);
+            } else if let Some(sleep) = this.sleep.as_pin_mut() {
+                match sleep.poll(cx) {
+                    Poll::Ready(()) => {
+                        *this.done = true;
+                        this.sleep.set(None);
+                    }
+                    Poll::Pending => {
+                        this.state.store_waker(cx.waker().clone());
+                        return Poll::Pending;
+                    }
+                }
+            }
+        }
+
+        match this.inner.as_pin_mut() {
+            Some(inner) => match inner.poll_frame(cx) {
+                Poll::Ready(Some(Ok(frame))) => Poll::Ready(Some(Ok(frame))),
+                Poll::Ready(Some(Err(e))) => Poll::Ready(Some(Err(Box::new(e)))),
+                Poll::Ready(None) => Poll::Ready(None),
+                Poll::Pending => Poll::Pending,
+            },
+            None => Poll::Ready(None),
+        }
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.inner.as_ref().map_or(true, |b| b.is_end_stream())
+    }
+
+    fn size_hint(&self) -> SizeHint {
+        self.inner
+            .as_ref()
+            .map_or_else(SizeHint::default, |b| b.size_hint())
+    }
+}

--- a/src/client/request.rs
+++ b/src/client/request.rs
@@ -565,41 +565,49 @@ impl RequestBuilder {
         self
     }
 
-    /// Register a callback for 1xx informational responses.
+    /// Enable `Expect: 100-continue` with the given timeout.
     ///
-    /// The callback is invoked when a 1xx informational response (such as
-    /// `100 Continue`) is received from the server, before the final response.
+    /// When set, the client sends the request headers first and waits
+    /// for a `100 Continue` response before sending the body. If the
+    /// timeout elapses before `100 Continue` arrives, the body is sent
+    /// anyway.
     ///
-    /// This is useful for handling the `Expect: 100-continue` flow, where
-    /// the client can decide when to send the request body after receiving
-    /// a `100 Continue` response.
+    /// This matches the behavior of Go's `http.Transport.ExpectContinueTimeout`
+    /// and curl's `--expect100-timeout`.
     ///
     /// # Example
     ///
     /// ```rust,no_run
     /// # use wreq::Error;
+    /// # use std::time::Duration;
     /// #
     /// # async fn run() -> Result<(), Error> {
-    /// use wreq::informational::Response;
-    ///
     /// let client = wreq::Client::new();
     /// let resp = client
-    ///     .post("http://httpbin.org/post")
-    ///     .body("data")
-    ///     .on_informational(|res: Response<'_>| {
-    ///         println!("Received: {}", res.status());
-    ///     })
+    ///     .post("http://example.com/upload")
+    ///     .body("large payload")
+    ///     .expect_continue_timeout(Duration::from_secs(1))
     ///     .send()
     ///     .await?;
     /// # Ok(())
     /// # }
     /// ```
-    pub fn on_informational<F>(mut self, callback: F) -> RequestBuilder
-    where
-        F: Fn(wreq_proto::ext::Response<'_>) + Send + Sync + 'static,
-    {
+    pub fn expect_continue_timeout(mut self, dur: Duration) -> RequestBuilder {
         if let Ok(ref mut req) = self.request {
-            wreq_proto::ext::on_informational(&mut req.0, callback);
+            req.headers_mut().insert(
+                http::header::EXPECT,
+                http::header::HeaderValue::from_static("100-continue"),
+            );
+
+            let state = super::expect_continue::ExpectContinueState::new();
+            let sig = state.clone();
+            wreq_proto::ext::on_informational(&mut req.0, move |_res| {
+                sig.signal();
+            });
+
+            let inner = req.body_mut().take().unwrap_or_else(Body::empty);
+            let wrapped = super::expect_continue::ExpectContinueBody::new(inner, state, dur);
+            *req.body_mut() = Some(Body::wrap(wrapped));
         }
         self
     }

--- a/src/client/request.rs
+++ b/src/client/request.rs
@@ -565,6 +565,45 @@ impl RequestBuilder {
         self
     }
 
+    /// Register a callback for 1xx informational responses.
+    ///
+    /// The callback is invoked when a 1xx informational response (such as
+    /// `100 Continue`) is received from the server, before the final response.
+    ///
+    /// This is useful for handling the `Expect: 100-continue` flow, where
+    /// the client can decide when to send the request body after receiving
+    /// a `100 Continue` response.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use wreq::Error;
+    /// #
+    /// # async fn run() -> Result<(), Error> {
+    /// use wreq::informational::Response;
+    ///
+    /// let client = wreq::Client::new();
+    /// let resp = client
+    ///     .post("http://httpbin.org/post")
+    ///     .body("data")
+    ///     .on_informational(|res: Response<'_>| {
+    ///         println!("Received: {}", res.status());
+    ///     })
+    ///     .send()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn on_informational<F>(mut self, callback: F) -> RequestBuilder
+    where
+        F: Fn(wreq_proto::ext::Response<'_>) + Send + Sync + 'static,
+    {
+        if let Ok(ref mut req) = self.request {
+            wreq_proto::ext::on_informational(&mut req.0, callback);
+        }
+        self
+    }
+
     /// Set the redirect policy for this request.
     pub fn redirect(mut self, policy: redirect::Policy) -> RequestBuilder {
         if let Ok(ref mut req) = self.request {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -346,15 +346,6 @@ pub mod http1 {
     pub use wreq_proto::http1::{Http1Options, Http1OptionsBuilder};
 }
 
-pub mod informational {
-    //! Types for handling HTTP 1xx informational responses.
-    //!
-    //! The [`Response`] type is used in the callback passed to
-    //! [`RequestBuilder::on_informational`](crate::RequestBuilder::on_informational).
-
-    pub use wreq_proto::ext::Response;
-}
-
 pub mod http2 {
     //! HTTP/2 protocol implementation and utilities.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -346,6 +346,15 @@ pub mod http1 {
     pub use wreq_proto::http1::{Http1Options, Http1OptionsBuilder};
 }
 
+pub mod informational {
+    //! Types for handling HTTP 1xx informational responses.
+    //!
+    //! The [`Response`] type is used in the callback passed to
+    //! [`RequestBuilder::on_informational`](crate::RequestBuilder::on_informational).
+
+    pub use wreq_proto::ext::Response;
+}
+
 pub mod http2 {
     //! HTTP/2 protocol implementation and utilities.
 


### PR DESCRIPTION
Closes #1148

## Summary

Add `expect_continue_timeout(Duration)` to `RequestBuilder`, enabling automatic `Expect: 100-continue` handling. The client sends headers first, waits for `100 Continue` (or timeout), then sends the body.

This matches the behavior of:
- Go's `http.Transport.ExpectContinueTimeout`
- curl's `--expect100-timeout`

Internally uses `wreq_proto::ext::on_informational` with a waker pattern — no callback exposed to users.

## Example usage

```rust
let client = wreq::Client::new();
let resp = client
    .post("http://example.com/upload")
    .body("large payload")
    .expect_continue_timeout(Duration::from_secs(1))
    .send()
    .await?;
```

## Changes

- `src/client/expect_continue.rs` — new: `ExpectContinueBody` wrapper that delays `poll_frame` until 100 Continue signal or timeout
- `src/client/request.rs` — replace `on_informational` callback with `expect_continue_timeout`
- `src/client.rs` — register new module
- `src/lib.rs` — remove `informational` module re-export

## Test plan

- [x] Code compiles
- [ ] Integration test with 100 Continue server

🤖 Generated with [Claude Code](https://claude.com/claude-code)
