### PR TITLE
chore: release v6.0.0-rc.30

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wreq"
-version = "6.0.0-rc.29"
+version = "6.0.0-rc.30"
 description = "An ergonomic, censorship-resistant Rust HTTP client"
 keywords = ["http", "client", "websocket", "ja3", "ja4"]
 categories = ["web-programming::http-client"]

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -172,6 +172,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - *(request)* static init for common content-type header ([#1060](https://github.com/0x676e67/wreq/pull/1060))
 ## [unreleased]
 
+## [6.0.0-rc.30](https://github.com/0x676e67/wreq/compare/v6.0.0-rc.29...v6.0.0-rc.30) - 2026-07-13
+
+### Added
+
+- *(dns)* implement `Error::is_dns()` to detect DNS resolve failures ([#1201](https://github.com/0x676e67/wreq/pull/1201))
+
+### Fixed
+
+- *(cookie)* correct domain matching ([#1209](https://github.com/0x676e67/wreq/pull/1209))
+
+### Other
+
+- Update .gitignore
+- *(badssl)* retry on `badssl.com` connection reset errors ([#1207](https://github.com/0x676e67/wreq/pull/1207))
+- update package description
+- *(badssl)* add test case for wrong host on BadSSL ([#1202](https://github.com/0x676e67/wreq/pull/1202))
+- add single-threaded benchmark for `cyper` HTTP Client ([#1195](https://github.com/0x676e67/wreq/pull/1195))
+
 ### Features
 
 - *(cookie)* RFC 9113 compliant cookie handling ([#1106](https://github.com/0x676e67/wreq/issues/1106)) - ([81f3adb](https://github.com/0x676e67/wreq/commit/81f3adb85e0fff869439bd4eac48405e78916c9a))

--- a/src/cookie.rs
+++ b/src/cookie.rs
@@ -5,8 +5,12 @@ use std::{collections::HashMap, convert::TryInto, fmt, sync::Arc, time::SystemTi
 use bytes::Bytes;
 use cookie::{Cookie as RawCookie, CookieJar, Expiration, SameSite, time::Duration};
 use http::{Uri, Version};
+use url::Host;
 
 use crate::{IntoUri, error::Error, ext::UriExt, header::HeaderValue, sync::RwLock};
+
+/// Canonical immutable host used as a cookie domain key.
+type CanonicalHost = Host<Box<str>>;
 
 /// Cookie header values in two forms.
 #[derive(Debug, Clone)]
@@ -66,7 +70,7 @@ pub struct Cookie<'a>(RawCookie<'a>);
 /// This type is exposed to allow creating one and filling it with some
 /// existing cookies more easily, before creating a [`crate::Client`].
 #[derive(Debug, Default)]
-pub struct Jar(RwLock<HashMap<String, HashMap<String, CookieJar>>>);
+pub struct Jar(RwLock<HashMap<CanonicalHost, HashMap<String, CookieJar>>>);
 
 // ===== impl IntoCookie =====
 
@@ -221,11 +225,11 @@ impl Jar {
     /// ```
     pub fn get<U: IntoUri>(&self, name: &str, uri: U) -> Option<Cookie<'static>> {
         let uri = uri.into_uri().ok()?;
-        let host = normalize_domain(uri.host()?);
+        let host = canonical_host(uri.host()?)?;
         let cookie = self
             .0
             .read()
-            .get(host)?
+            .get(&host)?
             .get(uri.path())?
             .get(name)?
             .clone()
@@ -257,7 +261,7 @@ impl Jar {
                         let mut cookie = cookie.clone().into_owned();
 
                         if cookie.domain().is_none() {
-                            cookie.set_domain(domain.to_owned());
+                            cookie.set_domain(domain.to_string());
                         }
 
                         if cookie.path().is_none() {
@@ -302,7 +306,7 @@ impl Jar {
             let mut cookie: RawCookie<'static> = cookie.into();
 
             // If the request-uri contains no host component:
-            let Some(host) = uri.host() else {
+            let Some(host) = uri.host().and_then(canonical_host) else {
                 return;
             };
 
@@ -313,14 +317,18 @@ impl Jar {
             // RFC 6265 §5.3 + §5.1.3:
             // https://datatracker.ietf.org/doc/html/rfc6265#section-5.3
             // https://datatracker.ietf.org/doc/html/rfc6265#section-5.1.3
-            let domain = if let Some(domain) = cookie.domain() {
-                let domain = normalize_domain(domain);
-                if domain.is_empty() || !domain_match(normalize_domain(host), domain) {
+            let domain = if let Some(raw_domain) = cookie.domain() {
+                let Some(domain) = canonical_host(raw_domain) else {
+                    return;
+                };
+                if !domain_match(&host, &domain) {
                     return;
                 }
+
+                cookie.set_domain(domain.to_string());
                 domain
             } else {
-                normalize_domain(host)
+                host
             };
 
             // If the request-uri contains no path component or if the first character of the
@@ -341,7 +349,7 @@ impl Jar {
 
             let mut inner = self.0.write();
             let name_map = inner
-                .entry(domain.to_owned())
+                .entry(domain)
                 .or_default()
                 .entry(path.to_owned())
                 .or_default();
@@ -382,9 +390,11 @@ impl Jar {
     {
         let uri = into_uri!(uri);
         if let Some(host) = uri.host() {
-            let host = normalize_domain(host);
+            let Some(host) = canonical_host(host) else {
+                return;
+            };
             let mut inner = self.0.write();
-            if let Some(path_map) = inner.get_mut(host) {
+            if let Some(path_map) = inner.get_mut(&host) {
                 if let Some(name_map) = path_map.get_mut(uri.path()) {
                     name_map.remove(cookie.into());
                 }
@@ -424,20 +434,32 @@ impl CookieStore for Jar {
 
     fn cookies(&self, uri: &Uri, version: Version) -> Cookies {
         let host = match uri.host() {
-            Some(h) => normalize_domain(h),
+            Some(host) => match canonical_host(host) {
+                Some(host) => host,
+                None => return Cookies::Empty,
+            },
             None => return Cookies::Empty,
         };
 
         let store = self.0.read();
+        let request_host = &host;
         let iter = store
             .iter()
-            .filter(|(domain, _)| domain_match(host, domain))
-            .flat_map(|(_, path_map)| {
+            .filter(|(domain, _)| domain_match(request_host, domain))
+            .flat_map(|(domain, path_map)| {
                 path_map
                     .iter()
                     .filter(|(path, _)| path_match(uri.path(), path))
-                    .flat_map(|(_, name_map)| {
-                        name_map.iter().filter(|cookie| {
+                    .flat_map(move |(_, name_map)| {
+                        name_map.iter().filter(move |cookie| {
+                            // RFC 6265 section 5.4 requires host-only cookies to match the
+                            // request host exactly. Only cookies with a Domain attribute may
+                            // be sent to matching subdomains.
+                            // https://www.rfc-editor.org/rfc/rfc6265.html#section-5.4
+                            if cookie.domain().is_none() && request_host != domain {
+                                return false;
+                            }
+
                             if cookie.secure() == Some(true) && uri.is_http() {
                                 return false;
                             }
@@ -499,18 +521,21 @@ const DEFAULT_PATH: &str = "/";
 /// [RFC 6265 section 5.1.3](https://datatracker.ietf.org/doc/html/rfc6265#section-5.1.3).
 ///
 /// - Returns true if the host and domain are identical.
-/// - Returns true if the host is a subdomain of the domain (host ends with ".domain").
+/// - Returns true if two DNS names have a matching dot-delimited domain suffix.
+/// - IP literals never use suffix matching.
 /// - Returns false otherwise.
-fn domain_match(host: &str, domain: &str) -> bool {
-    if domain.is_empty() {
-        return false;
-    }
+fn domain_match(host: &CanonicalHost, domain: &CanonicalHost) -> bool {
     if host == domain {
         return true;
     }
+
+    let (Host::Domain(host), Host::Domain(domain)) = (host, domain) else {
+        return false;
+    };
+
     host.len() > domain.len()
         && host.as_bytes()[host.len() - domain.len() - 1] == b'.'
-        && host.ends_with(domain)
+        && host.ends_with(domain.as_ref())
 }
 
 /// Determines if the request path matches the cookie path according to
@@ -528,17 +553,21 @@ fn path_match(req_path: &str, cookie_path: &str) -> bool {
                 || req_path[cookie_path.len()..].starts_with(DEFAULT_PATH))
 }
 
-/// Normalizes a domain by stripping any port information.
+/// Canonicalizes a DNS name or IP literal for cookie domain matching.
 ///
-/// According to [RFC 6265 section 5.2.3](https://datatracker.ietf.org/doc/html/rfc6265#section-5.2.3),
-/// the domain attribute of a cookie must not include a port. If a port is present (non-standard),
-/// it will be ignored for domain matching purposes.
-fn normalize_domain(domain: &str) -> &str {
-    let host_without_port = domain.split(':').next().unwrap_or(domain);
-    let without_leading = host_without_port
-        .strip_prefix(".")
-        .unwrap_or(host_without_port);
-    without_leading.strip_suffix(".").unwrap_or(without_leading)
+/// DNS names are converted to lowercase ASCII, while IPv4 and IPv6 addresses remain typed so
+/// they can only match exactly, as required by
+/// [RFC 6265 section 5.1.3](https://www.rfc-editor.org/rfc/rfc6265.html#section-5.1.3).
+fn canonical_host(host: &str) -> Option<CanonicalHost> {
+    // RFC 6265 section 5.2.3 requires a leading dot in Domain to be ignored.
+    // https://www.rfc-editor.org/rfc/rfc6265.html#section-5.2.3
+    let host = host.strip_prefix('.').unwrap_or(host);
+
+    match Host::parse(host).ok()? {
+        Host::Domain(domain) => Some(Host::Domain(domain.into_boxed_str())),
+        Host::Ipv4(address) => Some(Host::Ipv4(address)),
+        Host::Ipv6(address) => Some(Host::Ipv6(address)),
+    }
 }
 
 /// Computes the normalized default path for a cookie as specified in
@@ -707,6 +736,90 @@ mod tests {
                 "cookie must NOT be sent to {uri_str}"
             );
         }
+    }
+
+    #[test]
+    fn jar_does_not_send_host_only_cookie_to_subdomain() {
+        let jar = Jar::default();
+        jar.add("session=abc; Path=/", "http://example.com/login");
+
+        let origin = Uri::from_static("http://example.com/dashboard");
+        match jar.cookies(&origin, Version::HTTP_11) {
+            Cookies::Compressed(value) => assert_eq!(value, "session=abc"),
+            other => panic!("expected host-only cookie for origin host, got {other:?}"),
+        }
+
+        let subdomain = Uri::from_static("http://api.example.com/dashboard");
+        assert!(
+            matches!(jar.cookies(&subdomain, Version::HTTP_11), Cookies::Empty),
+            "host-only cookie must not be sent to a subdomain"
+        );
+    }
+
+    #[test]
+    fn jar_accepts_and_normalizes_mixed_case_domain() {
+        let jar = Jar::default();
+        jar.add(
+            "session=abc; Domain=EXAMPLE.COM; Path=/",
+            "https://example.com/login",
+        );
+
+        let cookies = jar.get_all().collect::<Vec<_>>();
+        assert_eq!(cookies.len(), 1);
+        assert_eq!(cookies[0].domain(), Some("example.com"));
+
+        let subdomain = Uri::from_static("https://api.example.com/dashboard");
+        match jar.cookies(&subdomain, Version::HTTP_11) {
+            Cookies::Compressed(value) => assert_eq!(value, "session=abc"),
+            other => panic!("expected domain cookie for matching subdomain, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn jar_ignores_leading_dot_in_domain() {
+        let jar = Jar::default();
+        jar.add(
+            "session=abc; Domain=.example.com; Path=/",
+            "https://example.com/login",
+        );
+
+        let subdomain = Uri::from_static("https://api.example.com/dashboard");
+        match jar.cookies(&subdomain, Version::HTTP_11) {
+            Cookies::Compressed(value) => assert_eq!(value, "session=abc"),
+            other => panic!("expected domain cookie for matching subdomain, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn jar_does_not_suffix_match_ipv4_addresses() {
+        let jar = Jar::default();
+        jar.add("session=abc; Domain=0.1; Path=/", "http://192.168.0.1/");
+
+        assert_eq!(jar.get_all().count(), 0);
+
+        let unrelated = Uri::from_static("http://10.0.0.1/");
+        assert!(matches!(
+            jar.cookies(&unrelated, Version::HTTP_11),
+            Cookies::Empty
+        ));
+    }
+
+    #[test]
+    fn jar_preserves_ipv6_host_identity() {
+        let jar = Jar::default();
+        jar.add("session=abc; Path=/", "http://[2001:db8::1]/");
+
+        let equivalent = Uri::from_static("http://[2001:0db8:0:0:0:0:0:1]/");
+        match jar.cookies(&equivalent, Version::HTTP_11) {
+            Cookies::Compressed(value) => assert_eq!(value, "session=abc"),
+            other => panic!("expected cookie for equivalent IPv6 host, got {other:?}"),
+        }
+
+        let unrelated = Uri::from_static("http://[2001:db8::2]/");
+        assert!(matches!(
+            jar.cookies(&unrelated, Version::HTTP_11),
+            Cookies::Empty
+        ));
     }
 
     #[test]


### PR DESCRIPTION



## 🤖 New release

* `wreq`: 6.0.0-rc.29 -> 6.0.0-rc.30 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [6.0.0-rc.29](https://github.com/0x676e67/wreq/compare/v6.0.0-rc.28...v6.0.0-rc.29) - 2026-06-02

### Added

- *(rt)* Add compio as optional runtime ([#1175](https://github.com/0x676e67/wreq/pull/1175))
- *(request)* expose Extensions for tower middleware compatibility ([#1119](https://github.com/0x676e67/wreq/pull/1119))
- *(request)* introduce `Group` for explicit request differentiation ([#1117](https://github.com/0x676e67/wreq/pull/1117))
- *(multipart)* use `WebKit` style boundary generation by default ([#1118](https://github.com/0x676e67/wreq/pull/1118))
- *(ws)* expose underlying stream via `WebSocket::into_inner` ([#1114](https://github.com/0x676e67/wreq/pull/1114))
- *(response)* allow forbidding connection recycling via `Response::forbid_recycle` ([#1110](https://github.com/0x676e67/wreq/pull/1110))
- *(cookie)* RFC 9113 compliant cookie handling ([#1106](https://github.com/0x676e67/wreq/pull/1106))
- *(tls)* allow pluggable TLS session cache ([#1101](https://github.com/0x676e67/wreq/pull/1101))
- *(multipart)* add Form::set_boundary for custom boundaries ([#1094](https://github.com/0x676e67/wreq/pull/1094))
- *(cookie)* fill missing domain/path in `get_all` from stored scope ([#1082](https://github.com/0x676e67/wreq/pull/1082))

### Fixed

- *(decoder)* disable tower-http default compression conditionally ([#1194](https://github.com/0x676e67/wreq/pull/1194))
- *(layer)* fix missing body timeout layer when custom layer ([#1186](https://github.com/0x676e67/wreq/pull/1186))
- *(response)* preserve URL info when decoding `bytes`/`json` errors ([#1189](https://github.com/0x676e67/wreq/pull/1189))
- *(http1)* fix possibly short reads when decoding a large body ([#1157](https://github.com/0x676e67/wreq/pull/1157))
- *(http1)* fix rare missed write wakeup on connections ([#1153](https://github.com/0x676e67/wreq/pull/1153))
- *(http1)* send error when dispatcher is dropped mid-body ([#1155](https://github.com/0x676e67/wreq/pull/1155))
- *(http2)* reading trailers shouldn't propagate NO_ERROR from early response ([#1156](https://github.com/0x676e67/wreq/pull/1156))
- *(tcp)* ensure socket bind options is not accidentally cleared ([#1131](https://github.com/0x676e67/wreq/pull/1131))
- *(http2)* cancel pipe_task and send `RST_STREAM` on response future drop ([#1116](https://github.com/0x676e67/wreq/pull/1116))
- *(http1)* allow keep-alive for chunked requests with trailers ([#1112](https://github.com/0x676e67/wreq/pull/1112))
- *(tcp)* restore the missing TCP nodelay setting ([#1102](https://github.com/0x676e67/wreq/pull/1102))
- *(bench)* fix CPU sysinfo reading in benchmark ([#1080](https://github.com/0x676e67/wreq/pull/1080))
- fix build
- disable Nagle's algorithm to resolve HTTP/2 performance dip ([#1074](https://github.com/0x676e67/wreq/pull/1074))
- *(http2)* prevent panic when calling to_str on non-UTF8 headers ([#1070](https://github.com/0x676e67/wreq/pull/1070))
- fix build
- *(rt)* support fake time in legacy client and TokioTimer ([#1064](https://github.com/0x676e67/wreq/pull/1064))

### Other

- perf
- *(group)* use `GroupId` to shrink owned identifier storage ([#1184](https://github.com/0x676e67/wreq/pull/1184))
- fix docs build warnings ([#1181](https://github.com/0x676e67/wreq/pull/1181))
- *(proxy)* fmt tests
- *(conn)* remove duplicate ALPN negotiation configuration ([#1176](https://github.com/0x676e67/wreq/pull/1176))
- *(trust)* improve unreachable branch in certificate loading ([#1173](https://github.com/0x676e67/wreq/pull/1173))
- *(header)* rename `OrigHeaderName to `HeaderCaseName` ([#1174](https://github.com/0x676e67/wreq/pull/1174))
- *(deps)* update deps
- *(keylog)* separate TLS keylog responsibilities ([#1166](https://github.com/0x676e67/wreq/pull/1166))
- update comments for tokio deps
- *(conn)* separate conn responsibilities ([#1165](https://github.com/0x676e67/wreq/pull/1165))
- fmt code ([#1164](https://github.com/0x676e67/wreq/pull/1164))
- *(deps)* update `wreq-proto` dependency version to 0.2.1 ([#1163](https://github.com/0x676e67/wreq/pull/1163))
- Enable git tagging in release configuration
- Update README.md
- rename toml
- Rename release-plz.toml to .release-plz.toml
- Add changelog path to release-plz configuration
- release-plz.yml
- *(core)* migrate core module to `wreq-proto` ([#1160](https://github.com/0x676e67/wreq/pull/1160))
- *(timer)* implement reset for `Sleep`, drop unsafe downcast ([#1159](https://github.com/0x676e67/wreq/pull/1159))
- *(deps)* update `lru` dependency version to 0.18.0 ([#1158](https://github.com/0x676e67/wreq/pull/1158))
- optimal network chunk sizes with usage scenarios
- revert
- *(tcp)* reduce dependency on `futures-util` ([#1154](https://github.com/0x676e67/wreq/pull/1154))
- *(deps)* update dependencies to latest versions
- fmt
- *(deps)* update http dependency version to 1.4.0 ([#1152](https://github.com/0x676e67/wreq/pull/1152))
- #[inline]
- *(deps)* update hickory-resolver requirement from 0.25 to 0.26 ([#1149](https://github.com/0x676e67/wreq/pull/1149))
- *(deps)* reduce dependency on `futures-channel` ([#1127](https://github.com/0x676e67/wreq/pull/1127))
- *(tls)* expose certificate compression APIs ([#1151](https://github.com/0x676e67/wreq/pull/1151))
- move
- fmt
- reduce benchmark noise interference
- Update Cargo.toml
- *(style)* fix clippy warnings for Rust 1.95.0 ([#1147](https://github.com/0x676e67/wreq/pull/1147))
- *(deps)* replace `serde_html_form` with `serde_urlencoded` ([#1146](https://github.com/0x676e67/wreq/pull/1146))
- *(deps)* update lru dependency version to 0.17.0 ([#1145](https://github.com/0x676e67/wreq/pull/1145))
- Update README.md
- *(http1/encode)* Add `inline` annotations to Encoder methods ([#1144](https://github.com/0x676e67/wreq/pull/1144))
- Change static to const for ALPHA_NUMERIC_ENCODING_MAP
- Update ci.yml
- *(cookie)* add subdomain cookie scoping tests for `Jar` ([#1143](https://github.com/0x676e67/wreq/pull/1143))
- *(tunnel)* standardize zero-copy parsing ([#1142](https://github.com/0x676e67/wreq/pull/1142))
- *(client)* Add 1 KB body case for benchmark
- *(deps)* bump softprops/action-gh-release from 2 to 3 ([#1140](https://github.com/0x676e67/wreq/pull/1140))
- *(http1/io)* leverage `tokio_util::io` to reduce vectorized write overhead ([#1141](https://github.com/0x676e67/wreq/pull/1141))
- update
- *(ws)* replace `force_http2` with `version` for HTTP version selection ([#1139](https://github.com/0x676e67/wreq/pull/1139))
- *(core)* fmt import ([#1138](https://github.com/0x676e67/wreq/pull/1138))
- *(sync)* fmt export ([#1136](https://github.com/0x676e67/wreq/pull/1136))
- *(deps)* optional `parking_lot` support ([#1126](https://github.com/0x676e67/wreq/pull/1126))
- *(layer)* add documentation comment
- *(deps)* update `http2` dependency version to 0.5.16 ([#1134](https://github.com/0x676e67/wreq/pull/1134))
- update examples
- *(group)* fmt code ([#1133](https://github.com/0x676e67/wreq/pull/1133))
- *(lib)* format exported http1 and http2 modules ([#1129](https://github.com/0x676e67/wreq/pull/1129))
- *(incoming)* fmt code
- *(bench/client)* fmt code
- Revert "bench: fmt code"
- *(deps)* remove implicit feature ([#1123](https://github.com/0x676e67/wreq/pull/1123))
- *(http2)* fmt code ([#1124](https://github.com/0x676e67/wreq/pull/1124))
- fmt code
- *(ws)* rewrite `sec-websocket-protocol` handling ([#1121](https://github.com/0x676e67/wreq/pull/1121))
- *(deps)* update `http2` dependency version to 0.5.15 ([#1122](https://github.com/0x676e67/wreq/pull/1122))
- *(ws)* "feat(request): introduce `Group` for explicit request differentiation" ([#1120](https://github.com/0x676e67/wreq/pull/1120))
- update SOCKS proxy support description in Cargo.toml
- Add Discord badge to README
- *(deps)* update `tokio-tungstenite` to version 0.29.0 ([#1113](https://github.com/0x676e67/wreq/pull/1113))
- *(response)* replace chunk usage with BodyExt::frame ([#1111](https://github.com/0x676e67/wreq/pull/1111))
- *(http2)* remove unstable APIs ([#1109](https://github.com/0x676e67/wreq/pull/1109))
- *(conn)* Fix comment for proxy handling in `Conn`
- Update RELEASE
- *(conn)* optimize `ConnectionId` cloning ([#1108](https://github.com/0x676e67/wreq/pull/1108))
- *(tcp)* prune redundant local address handling ([#1107](https://github.com/0x676e67/wreq/pull/1107))
- fmt code
- *(tls)* decouple TLS backend logic into sub-modules ([#1105](https://github.com/0x676e67/wreq/pull/1105))
- *(tls)* expose certificate compression APIs ([#1085](https://github.com/0x676e67/wreq/pull/1085))
- *(pool)* redesign emulation and pool ID strategy ([#1103](https://github.com/0x676e67/wreq/pull/1103))
- fmt import
- Fix cfg attribute formatting for set_tcp_user_timeout
- *(conn)* modular connector component ([#1100](https://github.com/0x676e67/wreq/pull/1100))
- update comments for compression support dependencies
- *(multipart)* streamline legacy Form implementation
- *(multipart)* Improve memory layout of `multipart::Form` ([#1095](https://github.com/0x676e67/wreq/pull/1095))
- *(buf)* make `BufList::remaining` O(1) by caching length ([#1091](https://github.com/0x676e67/wreq/pull/1091))
- *(deps)* bump btls from 0.5.3 to 0.5.4 ([#1090](https://github.com/0x676e67/wreq/pull/1090))
- Update README.md
- *(http1)* eliminate `ParserConfig` clones on the HTTP/1.1 request hot path ([#1088](https://github.com/0x676e67/wreq/pull/1088))
- *(bench)* update mod benchmark comment
- *(bench)* fmt code
- *(bench)* format expected error annotations
- Update README.md
- *(deps)* replace `ahash` with `foldhash` in `lru` cache ([#1084](https://github.com/0x676e67/wreq/pull/1084))
- *(deps)* migrate from `boring2` to `btls` ([#1083](https://github.com/0x676e67/wreq/pull/1083))
- *(request)* fmt imports for request.rs file
- Update README.md
- add missing `TokioTimer` to http1 server builder ([#1081](https://github.com/0x676e67/wreq/pull/1081))
- *(client)* fmt code
- *(deps)* replace `raw-cpuid` with `sysinfo` implementation ([#1077](https://github.com/0x676e67/wreq/pull/1077))
- *(hash)* simplify documentation for `HashMemo` creation ([#1076](https://github.com/0x676e67/wreq/pull/1076))
- format benchmark group labels
- improve benchmark test coverage ([#1075](https://github.com/0x676e67/wreq/pull/1075))
- fmt
- refactor `Cargo.toml` for clarity and organization
- remove deprecated doc_cfg feature conditionally
- simplify grouped benchmarks
- *(bench)* optimize benchmark server ([#1073](https://github.com/0x676e67/wreq/pull/1073))
- *(deps)* bump nttld/setup-ndk from 1.5.0 to 1.6.0 ([#1072](https://github.com/0x676e67/wreq/pull/1072))
- lint core ([#1071](https://github.com/0x676e67/wreq/pull/1071))
- include TLS-encrypted scenarios for HTTP/1 and HTTP/2
- Add benchmarks for full and streaming bodies ([#1069](https://github.com/0x676e67/wreq/pull/1069))
- clarify symbol conflict with OpenSSL ([#1068](https://github.com/0x676e67/wreq/pull/1068))
- Update hash.rs
- *(deps)* replace `schnellru` with `lru`  implementation ([#1066](https://github.com/0x676e67/wreq/pull/1066))
- Update git-cliff changelog
- Update CHANGELOG.md
- Update cliff.toml
- *(core)* clear code
- fix clippy
- add benchmarks for HTTP/1.1 and HTTP/2 ([#1065](https://github.com/0x676e67/wreq/pull/1065))
- *(http2)* backport and apply hyper client's H2 configuration ([#1063](https://github.com/0x676e67/wreq/pull/1063))
- *(response)* hint compiler to inline trivial response-handling functions ([#1062](https://github.com/0x676e67/wreq/pull/1062))
- *(error)* hint compiler to inline trivial error-handling functions ([#1061](https://github.com/0x676e67/wreq/pull/1061))
- *(request)* static init for common content-type header ([#1060](https://github.com/0x676e67/wreq/pull/1060))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).