### PR TITLE
feat(tls): allow sending the trust_anchors extension (draft-ietf-tls-trust-anchor-ids)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,10 @@ lru = "0.18.0"
 btls = "0.5.6"
 btls-sys = "0.5.6"
 tokio-btls = "0.5.6"
+# Direct dep so `ForeignTypeRef::as_ptr` is nameable on btls's `SslRef`/`Ssl`
+# when calling BoringSSL FFI that btls does not wrap (e.g. trust_anchors).
+# Already a transitive dependency via btls; promoting it adds no new resolution.
+foreign-types = "0.5"
 tokio = { version = "1.52.3", default-features = false }
 compio = { version = "0.19.0-rc.1", features = ["io", "io-compat"], optional = true }
 wreq-rt = { version = "0.2.2-rc.2", default-features = false }

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -162,6 +162,26 @@ pub struct TlsOptions {
     /// **Default:** `false`
     pub alps_use_new_codepoint: bool,
 
+    /// Requested trust anchor identifiers
+    /// ([draft-ietf-tls-trust-anchor-ids](https://datatracker.ietf.org/doc/draft-ietf-tls-trust-anchor-ids/)).
+    ///
+    /// When set, the client sends the TLS `trust_anchors` extension
+    /// (codepoint 0xca34 = 51764) in ClientHello, advertising the supplied
+    /// trust anchor IDs to the server.
+    ///
+    /// The value is the **wire-format** ID list: a series of non-empty,
+    /// 8-bit length-prefixed strings, as defined by the draft. wreq does not
+    /// validate the encoding; callers must supply a pre-formatted byte string.
+    ///
+    /// An **empty list** (`Some` of an empty slice) still sends the
+    /// `trust_anchors` extension with an empty value. This signals support for
+    /// the retry flow without requesting any specific trust anchor. `None`
+    /// (the default) sends no extension at all. The two states are intentionally
+    /// distinct and are not collapsed.
+    ///
+    /// **Default:** `None`
+    pub requested_trust_anchors: Option<Cow<'static, [u8]>>,
+
     /// Enables TLS Session Tickets ([RFC 5077](https://tools.ietf.org/html/rfc5077)).
     ///
     /// Allows session resumption without requiring server-side state.
@@ -491,6 +511,22 @@ impl TlsOptionsBuilder {
         self
     }
 
+    /// Sets the requested trust anchor identifiers (wire-format).
+    ///
+    /// The value must be the wire-format ID list described in
+    /// [`TlsOptions::requested_trust_anchors`]: a series of non-empty, 8-bit
+    /// length-prefixed strings. An empty slice sends the `trust_anchors`
+    /// extension with an empty value (retry-flow signal); use `None` (leave the
+    /// default) to send no extension at all.
+    #[inline]
+    pub fn requested_trust_anchors<T>(mut self, ids: T) -> Self
+    where
+        T: Into<Cow<'static, [u8]>>,
+    {
+        self.config.requested_trust_anchors = Some(ids.into());
+        self
+    }
+
     /// Sets the AES hardware override flag.
     #[inline]
     pub fn aes_hw_override<T>(mut self, enabled: T) -> Self
@@ -551,6 +587,7 @@ impl Default for TlsOptions {
             alpn_protocols: Some(Cow::Borrowed(&[AlpnProtocol::HTTP2, AlpnProtocol::HTTP1])),
             alps_protocols: None,
             alps_use_new_codepoint: false,
+            requested_trust_anchors: None,
             session_ticket: true,
             min_tls_version: None,
             max_tls_version: None,
@@ -614,5 +651,25 @@ mod tests {
 
         let alpn = AlpnProtocol::HTTP3.encode();
         assert_eq!(alpn, b"\x02h3".as_ref());
+    }
+
+    #[test]
+    fn requested_trust_anchors_roundtrip() {
+        // Absent: no extension is sent.
+        let opts = TlsOptions::builder().build();
+        assert!(opts.requested_trust_anchors.is_none());
+
+        // Empty wire list: the extension is still sent (retry-flow signal).
+        let opts = TlsOptions::builder()
+            .requested_trust_anchors(Vec::<u8>::new())
+            .build();
+        assert_eq!(opts.requested_trust_anchors.as_deref(), Some(&[][..]));
+
+        // Non-empty wire list: two 8-bit length-prefixed trust anchor IDs.
+        let wire: Vec<u8> = vec![0x03, b'a', b'b', b'c', 0x02, b'd', b'e'];
+        let opts = TlsOptions::builder()
+            .requested_trust_anchors(wire.clone())
+            .build();
+        assert_eq!(opts.requested_trust_anchors.as_deref(), Some(&wire[..]));
     }
 }

--- a/src/tls/conn.rs
+++ b/src/tls/conn.rs
@@ -20,6 +20,7 @@ use btls::{
     ssl::{Ssl, SslConnector, SslMethod, SslOptions, SslSessionCacheMode},
 };
 use ext::SslConnectorBuilderExt;
+use foreign_types::ForeignTypeRef;
 use http::{Uri, Version};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio_btls::SslStream;
@@ -52,6 +53,7 @@ pub struct HandshakeSettings {
     alps_protocols: Option<Cow<'static, [AlpsProtocol]>>,
     alps_use_new_codepoint: bool,
     key_shares: Option<Cow<'static, [KeyShare]>>,
+    requested_trust_anchors: Option<Cow<'static, [u8]>>,
     random_aes_hw_override: bool,
 }
 
@@ -191,6 +193,20 @@ impl TlsConnector {
         // Set TLS key shares
         if let Some(ref key_shares) = self.settings.key_shares {
             cfg.set_client_key_shares(key_shares.as_ref())?;
+        }
+
+        // Set requested trust anchor identifiers (trust_anchors extension,
+        // draft-ietf-tls-trust-anchor-ids). An empty list still sends the
+        // extension; `None` (the default) sends nothing.
+        if let Some(ref ids) = self.settings.requested_trust_anchors {
+            let ids = ids.as_ref();
+            #[allow(unsafe_code)]
+            let r = unsafe {
+                btls_sys::SSL_set1_requested_trust_anchors(cfg.as_ptr(), ids.as_ptr(), ids.len())
+            };
+            if r != 1 {
+                return Err(ErrorStack::get().into());
+            }
         }
 
         let uri = descriptor.uri().clone();
@@ -452,6 +468,7 @@ impl TlsConnectorBuilder {
             alps_use_new_codepoint: opts.alps_use_new_codepoint,
             enable_ech_grease: opts.enable_ech_grease,
             key_shares: opts.key_shares.clone(),
+            requested_trust_anchors: opts.requested_trust_anchors.clone(),
             random_aes_hw_override: opts.random_aes_hw_override,
         };
 


### PR DESCRIPTION
## Summary

Adds `TlsOptions::requested_trust_anchors`, letting a caller send the TLS `trust_anchors` extension (codepoint `0xca34` = 51764, [draft-ietf-tls-trust-anchor-ids](https://datatracker.ietf.org/doc/draft-ietf-tls-trust-anchor-ids/)) in the ClientHello.

Default is `None`, so nothing changes for existing users.

## Why

Real Chrome 148 sends 17 ClientHello extensions. Every wreq-based Chrome emulation currently sends 16 — `trust_anchors` is the missing one, and there is no way to add it: `TlsOptions` is a closed struct of fields with no callback into `SslConnectorBuilder`.

The visible consequence is that JA4 reads `t13d1516h2` where real Chrome reads `t13d1517h2`. Since JA4's first component encodes the extension count, that single missing extension is enough to distinguish a wreq client from the browser it claims to be in the User-Agent — which defeats the point of the preset Chrome profiles.

## Implementation

The vendored BoringSSL already implements this, and explicitly supports the empty case (`btls-sys/deps/boringssl/include/openssl/ssl.h`):

> If empty (`ids_len` is zero), the trust_anchors extension will still be sent in ClientHello. This may be used by a client application to signal support for the retry flow without requesting specific trust anchors.

So the change is thin:

- `TlsOptions::requested_trust_anchors: Option<Cow<'static, [u8]>>` holding the wire-format ID list, plus a builder setter modelled on `key_shares` / `extension_permutation`.
- Applied per-connection in `tls/conn.rs` next to the ALPS block via `SSL_set1_requested_trust_anchors`. `cfg` there is a `ConnectConfiguration` (derefs to `SslRef`), so the `SSL_set1_` variant is the correct one rather than `SSL_CTX_set1_`. A `0` return is surfaced as an error rather than discarded.

`Some(&[])` and `None` are deliberately distinct: the former sends an empty extension, the latter sends none. They are not collapsed.

`btls` exposes no safe wrapper for this function, so the call goes through the existing direct `btls-sys` dependency. It needs `foreign_types::ForeignTypeRef` in scope for `as_ptr()`; `foreign-types` was already in the tree transitively and is now named explicitly (the lockfile is unchanged). If you would rather this land as a safe wrapper in `btls` first, I am happy to open that PR instead and rebase this one on top — just say which you prefer.

## Verification

Unit tests cover the three builder states (absent, empty, non-empty wire list).

The extension actually reaching the wire is verified end-to-end downstream, against a fingerprint oracle that compares a live handshake to a reference captured from a real Chrome-for-Testing 148 build via `tls.browserleaks.com` and `tls.peet.ws`.

Same emulation profile, same oracle, same endpoints, only this patch applied in between:

```
reference (real Chrome 148.0.7778.178)   t13d1517h2_8daaf6152771_dcad5a053991
before                                   t13d1516h2_8daaf6152771_d8a2da3f94cd
after                                    t13d1517h2_8daaf6152771_dcad5a053991   exact match
```

Note the middle component — the cipher-suite hash — was already correct; it is the extension count (`1516` → `1517`) and the extension hash that move. `ja3n_hash` and `peetprint_hash` also go from mismatched to matching.

`ja3_hash` and `ja4_o` remain non-comparable by design, since Chrome permutes ClientHello extensions per handshake and the emulation uses a fixed order.

Gate on this branch: `cargo build --all-features`, `cargo test --lib` (83 passed, 0 skipped), `cargo clippy --all-targets -D warnings`, `cargo fmt --check` — all clean.
