### PR TITLE
docs: restore doc_cfg feature gate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 #![deny(unsafe_code)]
 #![deny(missing_docs)]
 #![cfg_attr(test, deny(warnings))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! # wreq
 //!


### PR DESCRIPTION
## Problem

The documentation build for wreq v6.0.0-rc.29 fails on docs.rs with E0658 because #[doc(cfg)] is experimental:

- [Failed docs.rs build for v6.0.0-rc.29](https://docs.rs/crate/wreq/6.0.0-rc.29/builds/3467503)

The package metadata passes --cfg docsrs to rustdoc. That activates the existing #[cfg_attr(docsrs, doc(cfg(...)))] annotations, but the crate-level doc_cfg feature gate is no longer present, so nightly rustdoc rejects those annotations.

## Background

The conditional doc_cfg feature gate was removed in [commit 29da5662](https://github.com/0x676e67/wreq/commit/29da5662789a9ef8092943a29912dbb77cdde275), whose message describes doc_cfg as deprecated.

However, doc_cfg itself has not been deprecated or stabilized upstream:

- [Rust tracking issue #43781](https://github.com/rust-lang/rust/issues/43781) remains open and still identifies doc_cfg as the feature gate for #[doc(cfg)].
- The Rust 1.92 changes removed the separate doc_auto_cfg and doc_cfg_hide feature gates by merging them into doc_cfg; they did not remove doc_cfg itself.
- [The doc_cfg stabilization PR #150055](https://github.com/rust-lang/rust/pull/150055) is still open and unmerged.

Therefore, crates using explicit #[doc(cfg(...))] annotations still need to enable doc_cfg when docs.rs builds them with nightly Rust.

## Fix

Restore the conditional crate attribute #![cfg_attr(docsrs, feature(doc_cfg))]. It is enabled only when cfg(docsrs) is set, so normal stable builds remain unaffected while docs.rs can build the feature availability annotations.

## Verification

Both checks completed successfully locally:

- cargo package
  - packaged 88 files and successfully verified the packaged wreq source
- cargo +nightly rustdoc --lib --all-features -- --cfg docsrs
  - generated target/doc/wreq/index.html successfully