### PR TITLE
Add C ABI wrapper and reusable Rust TLS client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,10 @@ readme = "README.md"
 license = "Apache-2.0"
 edition = "2024"
 rust-version = "1.85"
-include = ["README.md", "LICENSE", "src/**/*.rs"]
+include = ["README.md", "LICENSE", "src/**/*.rs", "include/wreq.h", "examples/WreqNative.cs"]
+
+[lib]
+crate-type = ["rlib", "cdylib"]
 
 [package.metadata.docs.rs]
 all-features = true
@@ -102,7 +105,7 @@ lru = "0.18.0"
 btls = "0.5.6"
 btls-sys = "0.5.6"
 tokio-btls = "0.5.6"
-tokio = { version = "1.52.3", default-features = false }
+tokio = { version = "1.52.3", default-features = false, features = ["rt-multi-thread", "time"] }
 compio = { version = "0.19.0-rc.1", features = ["io", "io-compat"], optional = true }
 wreq-rt = { version = "0.2.2-rc.2", default-features = false }
 wreq-proto = { version = "0.2.3", default-features = false }

--- a/README.md
+++ b/README.md
@@ -73,6 +73,22 @@ Due to the complexity of **TLS** encryption and the widespread adoption of **HTT
 
 **TLS** and **HTTP/2** fingerprints are often identical across various browser models because these underlying protocols evolve slower than browser release cycles. **100+ browser device emulation profiles** are maintained in [wreq-util](https://github.com/0x676e67/wreq-util).
 
+## C ABI and C#
+
+The crate also builds a `cdylib` for native callers. The ABI declarations are in
+[`include/wreq.h`](include/wreq.h), and the corresponding C# P/Invoke declarations
+are in [`examples/WreqNative.cs`](examples/WreqNative.cs). Request strings are
+borrowed NUL-terminated UTF-8 input. A successful response owns all returned
+strings and body bytes; release it with `wreq_response_free`. Release error
+strings with `wreq_error_free`.
+
+`Timeout` and `IdleTimeout` are milliseconds; the latter is mapped to wreq's
+per-request read timeout. `ProxyUrl`, `Headers`, `HeaderOrder`, `Body`, and
+`Cookies` are supported. `TlsProfile`, `Id`, and `CloseIdleConnections` are
+reserved because wreq has no named profile, request ID, or explicit idle-pool
+close operation. `HeaderOrder` is comma- or newline-separated and `Headers`
+uses `Name: value` lines.
+
 ## Building
 
 Compiling alongside **openssl-sys** can cause symbol conflicts with **boringssl** that lead to [link failures](https://github.com/cloudflare/boring/issues/197), and on **Linux** and **Android** this can be avoided by enabling the **`prefix-symbols`** feature.

--- a/README.md
+++ b/README.md
@@ -89,6 +89,17 @@ reserved because wreq has no named profile, request ID, or explicit idle-pool
 close operation. `HeaderOrder` is comma- or newline-separated and `Headers`
 uses `Name: value` lines.
 
+## Rust TLS client facade
+
+`wreq::tls_client::{TlsClient, TlsClientPool}` provides a reusable async client
+facade modeled after the Go `tls-client` flow. It supports per-ID client
+caching, proxy configuration, total/read timeouts, redirect policy, request
+headers/header order, and complete response collection. The current wreq
+repository does not contain a named browser-profile registry, so profile names
+other than `default` are rejected instead of silently using a different TLS
+fingerprint. Named profiles can be layered in by constructing the corresponding
+`wreq::Emulation` from the separate `wreq-util` crate.
+
 ## Building
 
 Compiling alongside **openssl-sys** can cause symbol conflicts with **boringssl** that lead to [link failures](https://github.com/cloudflare/boring/issues/197), and on **Linux** and **Android** this can be avoided by enabling the **`prefix-symbols`** feature.

--- a/examples/WreqNative.cs
+++ b/examples/WreqNative.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Runtime.InteropServices;
+
+internal static class WreqNative
+{
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct Request
+    {
+        public IntPtr ProxyUrl, Url, Method, Body;
+        public int Timeout, IdleTimeout;
+        public IntPtr Headers, HeaderOrder, TlsProfile, Id, Cookies;
+        [MarshalAs(UnmanagedType.I1)] public bool CloseIdleConnections;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct Response
+    {
+        public IntPtr Location, Protocol, Body;
+        public int BodyLength;
+        public IntPtr ContentType;
+        public int Status;
+        public IntPtr Headers, RequestUrl;
+    }
+
+    [DllImport("wreq", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern int wreq_execute(ref Request request, out IntPtr response, out IntPtr error);
+
+    [DllImport("wreq", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern void wreq_response_free(IntPtr response);
+
+    [DllImport("wreq", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern void wreq_error_free(IntPtr error);
+}

--- a/include/wreq.h
+++ b/include/wreq.h
@@ -1,0 +1,37 @@
+#ifndef WREQ_H
+#define WREQ_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+typedef struct {
+    char *ProxyUrl;
+    char *Url;
+    char *Method;
+    char *Body;
+    int Timeout;
+    int IdleTimeout;
+    char *Headers;
+    char *HeaderOrder;
+    char *TlsProfile;
+    char *Id;
+    char *Cookies;
+    bool CloseIdleConnections;
+} Request;
+
+typedef struct {
+    char *Location;
+    char *Protocol;
+    uint8_t *Body;
+    int BodyLength;
+    char *ContentType;
+    int Status;
+    char *Headers;
+    char *RequestUrl;
+} Response;
+
+int wreq_execute(const Request *request, Response **response, char **error);
+void wreq_response_free(Response *response);
+void wreq_error_free(char *error);
+
+#endif

--- a/src/c_abi.rs
+++ b/src/c_abi.rs
@@ -1,0 +1,401 @@
+//! Stable C ABI for the synchronous request path.
+//!
+//! Strings in [`Request`] are borrowed, NUL-terminated UTF-8 input strings.
+//! Strings and the body in [`Response`] are owned by the library and must be
+//! released with [`wreq_response_free`]. Error strings are released with
+//! [`wreq_error_free`].
+
+#![allow(unsafe_code)]
+
+use std::{
+    ffi::{CStr, CString},
+    os::raw::{c_char, c_int},
+    panic::{AssertUnwindSafe, catch_unwind},
+    ptr,
+    sync::OnceLock,
+    thread,
+    time::Duration,
+};
+
+use http::header::{HeaderMap, HeaderName, HeaderValue};
+use tokio::runtime::{Builder, Handle, Runtime};
+
+use crate::{Client, Method, Proxy, header::OrigHeaderMap};
+
+/// C-compatible request model.
+#[repr(C)]
+pub struct Request {
+    /// Optional proxy URL.
+    pub proxy_url: *const c_char,
+    /// Required request URL.
+    pub url: *const c_char,
+    /// Optional HTTP method; defaults to `GET`.
+    pub method: *const c_char,
+    /// Optional NUL-terminated request body.
+    pub body: *const c_char,
+    /// Total request timeout in milliseconds; zero disables the override.
+    pub timeout: c_int,
+    /// Per-read idle timeout in milliseconds; zero disables the override.
+    pub idle_timeout: c_int,
+    /// Headers as `Name: value` lines separated by CRLF or LF.
+    pub headers: *const c_char,
+    /// Header names in preferred order, separated by commas or CRLF.
+    pub header_order: *const c_char,
+    /// Unsupported by wreq; reserved for a future named emulation profile.
+    pub tls_profile: *const c_char,
+    /// Unsupported by wreq; retained for ABI compatibility.
+    pub id: *const c_char,
+    /// Optional value for the `Cookie` request header.
+    pub cookies: *const c_char,
+    /// Unsupported: wreq does not expose an explicit close-idle-connections operation.
+    pub close_idle_connections: bool,
+}
+
+/// C-compatible response model. All pointers are owned by the library.
+#[repr(C)]
+pub struct Response {
+    /// Redirect location, if present.
+    pub location: *mut c_char,
+    /// HTTP protocol version (`HTTP/1.0`, `HTTP/1.1`, or `HTTP/2.0`).
+    pub protocol: *mut c_char,
+    /// Response body bytes.
+    pub body: *mut u8,
+    /// Number of bytes at [`Response::body`].
+    pub body_length: c_int,
+    /// Content-Type header, if present.
+    pub content_type: *mut c_char,
+    /// HTTP status code.
+    pub status: c_int,
+    /// Response headers as CRLF-separated `Name: value` lines.
+    pub headers: *mut c_char,
+    /// Final request URL after wreq processing.
+    pub request_url: *mut c_char,
+}
+
+static RUNTIME: OnceLock<Runtime> = OnceLock::new();
+static CLIENT: OnceLock<Result<Client, String>> = OnceLock::new();
+
+fn runtime() -> &'static Runtime {
+    RUNTIME.get_or_init(|| {
+        Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("wreq C ABI runtime initialization failed")
+    })
+}
+
+fn c_string(value: &str) -> Result<CString, String> {
+    CString::new(value).map_err(|_| "value contains an embedded NUL byte".to_owned())
+}
+
+unsafe fn read_string(value: *const c_char, field: &str) -> Result<Option<String>, String> {
+    if value.is_null() {
+        return Ok(None);
+    }
+    unsafe { CStr::from_ptr(value) }
+        .to_str()
+        .map(str::to_owned)
+        .map(Some)
+        .map_err(|_| format!("{field} is not valid UTF-8"))
+}
+
+fn parse_headers(input: Option<&str>) -> Result<HeaderMap, String> {
+    let mut headers = HeaderMap::new();
+    let Some(input) = input else {
+        return Ok(headers);
+    };
+    for line in input.lines().filter(|line| !line.trim().is_empty()) {
+        let (name, value) = line
+            .split_once(':')
+            .ok_or_else(|| format!("invalid header line: {line}"))?;
+        let name = HeaderName::from_bytes(name.trim().as_bytes())
+            .map_err(|err| format!("invalid header name: {err}"))?;
+        let value = HeaderValue::from_str(value.trim())
+            .map_err(|err| format!("invalid header value: {err}"))?;
+        headers.append(name, value);
+    }
+    Ok(headers)
+}
+
+fn parse_header_order(input: Option<&str>) -> OrigHeaderMap {
+    let mut order = OrigHeaderMap::new();
+    if let Some(input) = input {
+        for name in input
+            .split(|ch: char| ch == ',' || ch == '\r' || ch == '\n')
+            .map(str::trim)
+            .filter(|name| !name.is_empty())
+        {
+            order.insert(name.to_owned());
+        }
+    }
+    order
+}
+
+fn protocol(version: http::Version) -> &'static str {
+    match version {
+        http::Version::HTTP_09 => "HTTP/0.9",
+        http::Version::HTTP_10 => "HTTP/1.0",
+        http::Version::HTTP_11 => "HTTP/1.1",
+        http::Version::HTTP_2 => "HTTP/2.0",
+        http::Version::HTTP_3 => "HTTP/3.0",
+        _ => "UNKNOWN",
+    }
+}
+
+fn serialize_headers(headers: &http::HeaderMap) -> String {
+    headers
+        .iter()
+        .map(|(name, value)| {
+            format!(
+                "{}: {}",
+                name,
+                value.to_str().unwrap_or("< non-UTF-8 header value >")
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\r\n")
+}
+
+struct OwnedResponse {
+    response: Response,
+}
+
+impl OwnedResponse {
+    fn new(response: crate::Response, body: Vec<u8>) -> Result<Self, String> {
+        let location = response
+            .headers()
+            .get("location")
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or("");
+        let content_type = response
+            .headers()
+            .get("content-type")
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or("");
+        let values = [
+            location.to_owned(),
+            protocol(response.version()).to_owned(),
+            content_type.to_owned(),
+            serialize_headers(response.headers()),
+            response.uri().to_string(),
+        ];
+        let mut allocations = values
+            .into_iter()
+            .map(|value| c_string(&value).map(CString::into_raw))
+            .collect::<Result<Vec<_>, _>>()?;
+        let body_length = c_int::try_from(body.len())
+            .map_err(|_| "response body is too large for the C ABI".to_owned())?;
+        let body = body.into_boxed_slice();
+        let body_ptr = Box::into_raw(body) as *mut u8;
+        let response = Response {
+            location: allocations.remove(0),
+            protocol: allocations.remove(0),
+            body: body_ptr,
+            body_length,
+            content_type: allocations.remove(0),
+            status: c_int::from(response.status().as_u16()),
+            headers: allocations.remove(0),
+            request_url: allocations.remove(0),
+        };
+        Ok(Self { response })
+    }
+
+    fn into_raw(self) -> *mut Response {
+        Box::into_raw(Box::new(self.response))
+    }
+}
+
+async fn execute_request(request: Request) -> Result<OwnedResponse, String> {
+    let proxy = unsafe { read_string(request.proxy_url, "ProxyUrl")? };
+    let url =
+        unsafe { read_string(request.url, "Url")? }.ok_or_else(|| "Url is required".to_owned())?;
+    let method = unsafe { read_string(request.method, "Method")? }?.unwrap_or_else(|| "GET".into());
+    let body = unsafe { read_string(request.body, "Body")? };
+    let headers = parse_headers(unsafe { read_string(request.headers, "Headers")? }.as_deref())?;
+    let header_order =
+        parse_header_order(unsafe { read_string(request.header_order, "HeaderOrder")? }.as_deref());
+    let cookies = unsafe { read_string(request.cookies, "Cookies")? };
+
+    let client = CLIENT
+        .get_or_init(|| {
+            Client::builder()
+                .build()
+                .map_err(|err| format!("client initialization failed: {err}"))
+        })
+        .as_ref()
+        .map_err(Clone::clone)?;
+    let method = Method::from_bytes(method.as_bytes())
+        .map_err(|err| format!("invalid HTTP method: {err}"))?;
+    let mut builder = client.request(method, url);
+    if let Some(proxy) = proxy {
+        builder =
+            builder.proxy(Proxy::all(proxy).map_err(|err| format!("invalid proxy URL: {err}"))?);
+    }
+    builder = builder.headers(headers).orig_headers(header_order);
+    if let Some(cookies) = cookies {
+        builder = builder.header("cookie", cookies);
+    }
+    if let Some(body) = body {
+        builder = builder.body(body.into_bytes());
+    }
+    if request.timeout > 0 {
+        builder = builder.timeout(Duration::from_millis(request.timeout as u64));
+    }
+    if request.idle_timeout > 0 {
+        builder = builder.read_timeout(Duration::from_millis(request.idle_timeout as u64));
+    }
+    let response = builder
+        .send()
+        .await
+        .map_err(|err| format!("request failed: {err}"))?;
+    let body = response
+        .bytes()
+        .await
+        .map_err(|err| format!("response body failed: {err}"))?
+        .to_vec();
+    OwnedResponse::new(response, body)
+}
+
+fn run_request(request: Request) -> Result<OwnedResponse, String> {
+    let future = execute_request(request);
+    if Handle::try_current().is_ok() {
+        thread::spawn(move || runtime().block_on(future))
+            .join()
+            .map_err(|_| "request worker thread panicked".to_owned())?
+    } else {
+        runtime().block_on(future)
+    }
+}
+
+fn error_ptr(message: impl AsRef<str>) -> *mut c_char {
+    let message = message.as_ref().replace('\0', "\\0");
+    CString::new(message).expect("NUL was replaced").into_raw()
+}
+
+/// Executes one request. Returns zero on success and nonzero on failure.
+///
+/// `response_out` and `error_out` must be non-null. On success, `*response_out`
+/// is released with [`wreq_response_free`]. On failure, `*error_out` is released
+/// with [`wreq_error_free`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wreq_execute(
+    request: *const Request,
+    response_out: *mut *mut Response,
+    error_out: *mut *mut c_char,
+) -> c_int {
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        if request.is_null() || response_out.is_null() || error_out.is_null() {
+            return Err("request, response_out, and error_out are required".to_owned());
+        }
+        unsafe {
+            *response_out = ptr::null_mut();
+            *error_out = ptr::null_mut();
+            let response = run_request(ptr::read(request))?;
+            *response_out = response.into_raw();
+        }
+        Ok(())
+    }));
+    match result {
+        Ok(Ok(())) => 0,
+        Ok(Err(error)) => {
+            if !error_out.is_null() {
+                unsafe {
+                    *error_out = error_ptr(error);
+                }
+            }
+            1
+        }
+        Err(_) => {
+            if !error_out.is_null() {
+                unsafe {
+                    *error_out = error_ptr("panic while executing request");
+                }
+            }
+            1
+        }
+    }
+}
+
+/// Releases a response returned by [`wreq_execute`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wreq_response_free(response: *mut Response) {
+    if response.is_null() {
+        return;
+    }
+    unsafe {
+        let response = Box::from_raw(response);
+        if !response.location.is_null() {
+            drop(CString::from_raw(response.location));
+        }
+        if !response.protocol.is_null() {
+            drop(CString::from_raw(response.protocol));
+        }
+        if !response.body.is_null() {
+            drop(Vec::from_raw_parts(
+                response.body,
+                response.body_length.max(0) as usize,
+                response.body_length.max(0) as usize,
+            ));
+        }
+        if !response.content_type.is_null() {
+            drop(CString::from_raw(response.content_type));
+        }
+        if !response.headers.is_null() {
+            drop(CString::from_raw(response.headers));
+        }
+        if !response.request_url.is_null() {
+            drop(CString::from_raw(response.request_url));
+        }
+    }
+}
+
+/// Releases an error string returned by [`wreq_execute`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wreq_error_free(error: *mut c_char) {
+    if !error.is_null() {
+        unsafe {
+            drop(CString::from_raw(error));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_headers_and_order() {
+        let headers = parse_headers(Some("X-Test: one\r\nX-Test: two")).unwrap();
+        assert_eq!(headers.get_all("x-test").iter().count(), 2);
+        let order = parse_header_order(Some("Host, X-Test\r\nCookie"));
+        assert_eq!(order.len(), 3);
+    }
+
+    #[test]
+    fn response_ownership_can_be_freed() {
+        let response = Box::into_raw(Box::new(Response {
+            location: c_string("").unwrap().into_raw(),
+            protocol: c_string("HTTP/1.1").unwrap().into_raw(),
+            body: Box::into_raw(vec![1_u8, 2].into_boxed_slice()) as *mut u8,
+            body_length: 2,
+            content_type: c_string("").unwrap().into_raw(),
+            status: 200,
+            headers: c_string("").unwrap().into_raw(),
+            request_url: c_string("http://example.test").unwrap().into_raw(),
+        }));
+        unsafe {
+            wreq_response_free(response);
+        }
+    }
+
+    #[test]
+    fn invalid_request_returns_owned_error() {
+        let mut response = ptr::null_mut();
+        let mut error = ptr::null_mut();
+        let status = unsafe { wreq_execute(ptr::null(), &mut response, &mut error) };
+        assert_eq!(status, 1);
+        assert!(response.is_null());
+        assert!(!error.is_null());
+        unsafe { wreq_error_free(error) };
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -301,6 +301,7 @@ macro_rules! if_no_rt {
 mod trace;
 /// C ABI bindings for consuming wreq from native applications and C#.
 pub mod c_abi;
+pub mod tls_client;
 #[macro_use]
 mod ext;
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -299,6 +299,8 @@ macro_rules! if_no_rt {
 
 #[macro_use]
 mod trace;
+/// C ABI bindings for consuming wreq from native applications and C#.
+pub mod c_abi;
 #[macro_use]
 mod ext;
 #[macro_use]

--- a/src/tls_client.rs
+++ b/src/tls_client.rs
@@ -1,0 +1,239 @@
+//! Reusable TLS-aware client facade modeled after the Go `tls-client` API.
+
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use crate::{
+    Client, Method, Proxy,
+    header::{HeaderMap, HeaderName, HeaderValue, OrigHeaderMap},
+    redirect::Policy,
+};
+
+/// Configuration used to construct a [`TlsClient`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TlsClientConfig {
+    /// Named profile. `default` and the empty string use wreq defaults.
+    ///
+    /// Named browser profiles require the separate `wreq-util` crate and are
+    /// intentionally rejected here rather than silently emulated incorrectly.
+    pub tls_profile: String,
+    /// Total request timeout.
+    pub timeout: Option<Duration>,
+    /// Timeout while waiting for the next response-body read.
+    pub idle_timeout: Option<Duration>,
+    /// Optional proxy URL.
+    pub proxy_url: Option<String>,
+    /// Whether redirects should be followed.
+    pub follow_redirects: bool,
+    /// Disable certificate and hostname verification.
+    pub insecure_skip_verify: bool,
+}
+
+impl Default for TlsClientConfig {
+    fn default() -> Self {
+        Self {
+            tls_profile: String::new(),
+            timeout: Some(Duration::from_secs(30)),
+            idle_timeout: Some(Duration::from_secs(30)),
+            proxy_url: None,
+            follow_redirects: false,
+            insecure_skip_verify: false,
+        }
+    }
+}
+
+/// A fully configured, shareable HTTP client.
+#[derive(Clone)]
+pub struct TlsClient {
+    client: Client,
+    config: TlsClientConfig,
+}
+
+/// A collected response returned by [`TlsClient::execute`].
+#[derive(Debug, Clone)]
+pub struct TlsResponse {
+    /// Final response URL.
+    pub url: String,
+    /// HTTP status code.
+    pub status: u16,
+    /// Negotiated HTTP protocol version.
+    pub protocol: crate::Version,
+    /// Response headers.
+    pub headers: HeaderMap,
+    /// Full response body.
+    pub body: Vec<u8>,
+}
+
+impl TlsClient {
+    /// Builds a client from configuration.
+    pub fn new(config: TlsClientConfig) -> crate::Result<Self> {
+        if !config.tls_profile.is_empty() && config.tls_profile != "default" {
+            return Err(crate::Error::builder(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!(
+                    "unsupported TLS profile {:?}; use wreq-util to provide named emulation",
+                    config.tls_profile
+                ),
+            )));
+        }
+
+        let mut builder = Client::builder();
+        if let Some(proxy_url) = &config.proxy_url {
+            builder = builder.proxy(Proxy::all(proxy_url)?);
+        }
+        if let Some(timeout) = config.timeout {
+            builder = builder.timeout(timeout);
+        }
+        builder = builder.redirect(if config.follow_redirects {
+            Policy::limited(10)
+        } else {
+            Policy::none()
+        });
+        if config.insecure_skip_verify {
+            builder = builder
+                .tls_cert_verification(false)
+                .tls_verify_hostname(false);
+        }
+        Ok(Self {
+            client: builder.build()?,
+            config,
+        })
+    }
+
+    /// Executes a request and collects its complete response body.
+    pub async fn execute(
+        &self,
+        method: Method,
+        url: impl Into<String>,
+        headers: HeaderMap,
+        header_order: OrigHeaderMap,
+        body: Option<Vec<u8>>,
+    ) -> crate::Result<TlsResponse> {
+        let mut request = self.client.request(method, url.into());
+        request = request.headers(headers).orig_headers(header_order);
+        if let Some(body) = body {
+            request = request.body(body);
+        }
+        if let Some(timeout) = self.config.timeout {
+            request = request.timeout(timeout);
+        }
+        if let Some(timeout) = self.config.idle_timeout {
+            request = request.read_timeout(timeout);
+        }
+        let response = request.send().await?;
+        let result = TlsResponse {
+            url: response.uri().to_string(),
+            status: response.status().as_u16(),
+            protocol: response.version(),
+            headers: response.headers().clone(),
+            body: response.bytes().await?.to_vec(),
+        };
+        Ok(result)
+    }
+
+    /// Returns the immutable configuration used to create this client.
+    pub fn config(&self) -> &TlsClientConfig {
+        &self.config
+    }
+}
+
+/// Thread-safe cache of clients keyed by the Go implementation's `Id` field.
+#[derive(Default, Clone)]
+pub struct TlsClientPool {
+    clients: Arc<Mutex<HashMap<String, (TlsClientConfig, Arc<TlsClient>)>>>,
+}
+
+impl TlsClientPool {
+    /// Returns a cached client or creates one when the configuration changed.
+    pub fn get_or_create(
+        &self,
+        id: impl Into<String>,
+        config: TlsClientConfig,
+    ) -> crate::Result<Arc<TlsClient>> {
+        let id = id.into();
+        let mut clients = self.clients.lock().map_err(|_| {
+            crate::Error::builder(std::io::Error::other("TLS client pool lock poisoned"))
+        })?;
+        if let Some((cached_config, client)) = clients.get(&id) {
+            if cached_config == &config {
+                return Ok(Arc::clone(client));
+            }
+        }
+        let client = Arc::new(TlsClient::new(config.clone())?);
+        clients.insert(id, (config, Arc::clone(&client)));
+        Ok(client)
+    }
+
+    /// Removes a cached client. Dropping it closes its pool when no other
+    /// `TlsClient` clone is alive; wreq has no explicit close-idle operation.
+    pub fn remove(&self, id: &str) -> crate::Result<bool> {
+        let mut clients = self.clients.lock().map_err(|_| {
+            crate::Error::builder(std::io::Error::other("TLS client pool lock poisoned"))
+        })?;
+        Ok(clients.remove(id).is_some())
+    }
+}
+
+/// Parses `Name: value` lines into request headers.
+pub fn parse_headers(input: &str) -> crate::Result<HeaderMap> {
+    let mut headers = HeaderMap::new();
+    for line in input.lines().filter(|line| !line.trim().is_empty()) {
+        let (name, value) = line.split_once(':').ok_or_else(|| {
+            crate::Error::builder(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("invalid header line: {line}"),
+            ))
+        })?;
+        let name = HeaderName::from_bytes(name.trim().as_bytes()).map_err(|error| {
+            crate::Error::builder(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                error.to_string(),
+            ))
+        })?;
+        let value = HeaderValue::from_str(value.trim()).map_err(|error| {
+            crate::Error::builder(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                error.to_string(),
+            ))
+        })?;
+        headers.append(name, value);
+    }
+    Ok(headers)
+}
+
+/// Parses comma- or newline-separated header names.
+pub fn parse_header_order(input: &str) -> OrigHeaderMap {
+    let mut order = OrigHeaderMap::new();
+    for name in input
+        .split(|ch: char| ch == ',' || ch == '\r' || ch == '\n')
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+    {
+        order.insert(name.to_owned());
+    }
+    order
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_go_header_formats() {
+        let headers = parse_headers("Host: example.test\r\nX-Test: value").unwrap();
+        assert_eq!(headers["host"], "example.test");
+        assert_eq!(parse_header_order("Host\r\nX-Test").len(), 2);
+    }
+
+    #[test]
+    fn rejects_unknown_named_profiles() {
+        let config = TlsClientConfig {
+            tls_profile: "chrome_146".into(),
+            ..Default::default()
+        };
+        assert!(TlsClient::new(config).is_err());
+    }
+}


### PR DESCRIPTION
## Why

Expose wreq to C# and provide a reusable Rust TLS client facade modeled after the existing Go TlsClient implementation.

## What changed

- Add a production-oriented C ABI with compatible Request/Response layouts, exported request execution and response/error ownership APIs, and a C header.
- Add C# P/Invoke declarations and a minimal native usage example.
- Add `TlsClient`, `TlsClientPool`, header/header-order parsing, ID-based client reuse, proxy and timeout configuration, redirects, complete response collection, and explicit handling for unsupported named TLS profiles.
- Document the Rust TLS client behavior and current profile limitations.

## Validation

- `cargo fmt --all -- --check`
- `cargo metadata --no-deps`
- `git diff --check`
- Focused cargo tests were attempted but could not complete because the environment lacks `libclang.dll` required by `btls-sys`.