### PR TITLE
WreqTlsClient

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -353,3 +353,7 @@ path = "examples/unix_socket.rs"
 name = "rt"
 path = "examples/rt.rs"
 required-features = ["compio-rt"]
+
+[[example]]
+name = "external_client"
+path = "examples/external_client.rs"

--- a/README.md
+++ b/README.md
@@ -59,6 +59,30 @@ async fn main() -> wreq::Result<()> {
 }
 ```
 
+### Keeping the dependency behind an application boundary
+
+When `wreq` is used by a larger application, keep its API in a small adapter
+module. This makes upgrades easier because the rest of the application depends
+on the adapter's stable methods instead of on `wreq` request builders directly.
+The repository includes a complete example in
+[`examples/external_client.rs`](examples/external_client.rs) and
+[`examples/support/wreq_client.rs`](examples/support/wreq_client.rs).
+
+The dependency can use a compatible release range while still selecting the
+features required by the application:
+
+```toml
+[dependencies]
+wreq = { version = "6.0.0-rc", default-features = true }
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+```
+
+Run the example with:
+
+```bash
+cargo run --example external_client
+```
+
 ## Behavior
 
 - **HTTP/1 over TLS**

--- a/examples/external_client.rs
+++ b/examples/external_client.rs
@@ -1,0 +1,15 @@
+//! Example application using `wreq` through a small local integration boundary.
+
+#[path = "support/wreq_client.rs"]
+mod wreq_client;
+
+use wreq_client::HttpClient;
+
+#[tokio::main]
+async fn main() -> wreq::Result<()> {
+    let client = HttpClient::new()?;
+    let body = client.get_text("https://www.rust-lang.org").await?;
+
+    println!("received {} bytes", body.len());
+    Ok(())
+}

--- a/examples/support/wreq_client.rs
+++ b/examples/support/wreq_client.rs
@@ -1,0 +1,20 @@
+//! Application-facing boundary around `wreq`.
+
+/// Small HTTP client facade that keeps `wreq` details out of application code.
+pub struct HttpClient {
+    inner: wreq::Client,
+}
+
+impl HttpClient {
+    /// Builds a client using the features configured by the `wreq` dependency.
+    pub fn new() -> wreq::Result<Self> {
+        Ok(Self {
+            inner: wreq::Client::builder().build()?,
+        })
+    }
+
+    /// Sends a GET request and returns its response body as text.
+    pub async fn get_text(&self, url: &str) -> wreq::Result<String> {
+        self.inner.get(url).send().await?.text().await
+    }
+}


### PR DESCRIPTION
wreq を外部ライブラリとして利用する薄い HttpClient 境界、実行例、Cargo.toml 登録、README の利用手順を追加しました。

検証: cargo fmt --all -- --check、git diff --check は成功。cargo check --example external_client は btls-sys の BoringSSL ビルド時に環境の libclang.dll 不在で停止しました。