### PR TITLE
chore: release v6.0.0-rc.31

### DIFF
--- a/.github/.release-plz.toml
+++ b/.github/.release-plz.toml
@@ -1,5 +1,6 @@
 [workspace]
 # set the path of all the crates to the changelog to the root of the repository
 changelog_path = "./RELEASE.md"
+release_always = false
 git_tag_enable = true
 git_tag_name = "v{{ version }}"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wreq"
-version = "6.0.0-rc.30"
+version = "6.0.0-rc.31"
 description = "An ergonomic, privacy-aware Rust HTTP Client"
 keywords = ["http", "client", "websocket", "ja3", "ja4"]
 categories = ["web-programming::http-client"]
@@ -11,7 +11,7 @@ readme = "README.md"
 license = "Apache-2.0"
 edition = "2024"
 rust-version = "1.85"
-include = ["README.md", "LICENSE", "src/**/*.rs"]
+include = ["/README.md", "/LICENSE", "/src/**/*.rs"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.0.0-rc.31](https://github.com/0x676e67/wreq/compare/v6.0.0-rc.29...v6.0.0-rc.31) - 2026-08-18
+
+### Added
+
+- *(socket)* tcp SO_LINGER option ([#1217](https://github.com/0x676e67/wreq/pull/1217))
+- *(cookie)* expand cookie jar APIs ([#1216](https://github.com/0x676e67/wreq/pull/1216))
+- *(dns)* implement `Error::is_dns()` to detect DNS resolve failures ([#1201](https://github.com/0x676e67/wreq/pull/1201))
+
+### Fixed
+
+- *(release)* restore changelog parsing ([#1244](https://github.com/0x676e67/wreq/pull/1244))
+- *(error)* classify read timeout as body error ([#1233](https://github.com/0x676e67/wreq/pull/1233))
+- *(proxy)* handle WinINET IP wildcards ([#1226](https://github.com/0x676e67/wreq/pull/1226))
+- *(socket)* prefer ready connection at timeout boundary
+- *(socket)* race resolved addresses within connect timeout
+- *(cookie)* enforce max-age expiration ([#1214](https://github.com/0x676e67/wreq/pull/1214))
+- *(cookie)* correct domain matching ([#1211](https://github.com/0x676e67/wreq/pull/1211))
+
+### Other
+
+- *(redirect)* cover sensitive headers on scheme changes ([#1236](https://github.com/0x676e67/wreq/pull/1236))
+- *(request)* document JSON content type ([#1235](https://github.com/0x676e67/wreq/pull/1235))
+- add pull request template for human-written content ([#1232](https://github.com/0x676e67/wreq/pull/1232))
+- *(body)* use absolute read timeout deadline ([#1231](https://github.com/0x676e67/wreq/pull/1231))
+- *(deps)* bump taiki-e/install-action from 2.85.5 to 2.85.10 ([#1229](https://github.com/0x676e67/wreq/pull/1229))
+- *(body)* reuse read timeout timer ([#1230](https://github.com/0x676e67/wreq/pull/1230))
+- restore doc_cfg feature gate ([#1228](https://github.com/0x676e67/wreq/pull/1228))
+- *(client)* centralize IPv6 bracket parsing ([#1227](https://github.com/0x676e67/wreq/pull/1227))
+- Merge pull request #1203 from 0x676e67/dependabot/github_actions/actions/checkout-7
+- Merge pull request #1224 from 0x676e67/fix/multi-ip-connect-timeout-157-1
+- update
+- move release-plz config to .github
+- *(redirect)* simplify internal abstractions for redirect handling ([#1200](https://github.com/0x676e67/wreq/pull/1200))
+- *(deps)* update package dependency versions
+- update examples
+- fix clippy lints for Rust 1.97.0 ([#1213](https://github.com/0x676e67/wreq/pull/1213))
+- Update .gitignore
+- *(badssl)* retry on `badssl.com` connection reset errors ([#1207](https://github.com/0x676e67/wreq/pull/1207))
+- update package description
+- *(badssl)* add test case for wrong host on BadSSL ([#1202](https://github.com/0x676e67/wreq/pull/1202))
+- add single-threaded benchmark for `cyper` HTTP Client ([#1195](https://github.com/0x676e67/wreq/pull/1195))
+
 ## [6.0.0-rc.29](https://github.com/0x676e67/wreq/compare/v6.0.0-rc.28...v6.0.0-rc.29) - 2026-06-02
 
 ### Added


### PR DESCRIPTION
## New release

* `wreq`: 6.0.0-rc.30 -> 6.0.0-rc.31 (API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [6.0.0-rc.31](https://github.com/0x676e67/wreq/compare/v6.0.0-rc.29...v6.0.0-rc.31) - 2026-08-18

### Added

- *(socket)* tcp SO_LINGER option ([#1217](https://github.com/0x676e67/wreq/pull/1217))
- *(cookie)* expand cookie jar APIs ([#1216](https://github.com/0x676e67/wreq/pull/1216))
- *(dns)* implement `Error::is_dns()` to detect DNS resolve failures ([#1201](https://github.com/0x676e67/wreq/pull/1201))

### Fixed

- *(release)* restore changelog parsing ([#1244](https://github.com/0x676e67/wreq/pull/1244))
- *(error)* classify read timeout as body error ([#1233](https://github.com/0x676e67/wreq/pull/1233))
- *(proxy)* handle WinINET IP wildcards ([#1226](https://github.com/0x676e67/wreq/pull/1226))
- *(socket)* prefer ready connection at timeout boundary
- *(socket)* race resolved addresses within connect timeout
- *(cookie)* enforce max-age expiration ([#1214](https://github.com/0x676e67/wreq/pull/1214))
- *(cookie)* correct domain matching ([#1211](https://github.com/0x676e67/wreq/pull/1211))

### Other

- *(redirect)* cover sensitive headers on scheme changes ([#1236](https://github.com/0x676e67/wreq/pull/1236))
- *(request)* document JSON content type ([#1235](https://github.com/0x676e67/wreq/pull/1235))
- add pull request template for human-written content ([#1232](https://github.com/0x676e67/wreq/pull/1232))
- *(body)* use absolute read timeout deadline ([#1231](https://github.com/0x676e67/wreq/pull/1231))
- *(deps)* bump taiki-e/install-action from 2.85.5 to 2.85.10 ([#1229](https://github.com/0x676e67/wreq/pull/1229))
- *(body)* reuse read timeout timer ([#1230](https://github.com/0x676e67/wreq/pull/1230))
- restore doc_cfg feature gate ([#1228](https://github.com/0x676e67/wreq/pull/1228))
- *(client)* centralize IPv6 bracket parsing ([#1227](https://github.com/0x676e67/wreq/pull/1227))
- Merge pull request #1203 from 0x676e67/dependabot/github_actions/actions/checkout-7
- Merge pull request #1224 from 0x676e67/fix/multi-ip-connect-timeout-157-1
- update
- move release-plz config to .github
- *(redirect)* simplify internal abstractions for redirect handling ([#1200](https://github.com/0x676e67/wreq/pull/1200))
- *(deps)* update package dependency versions
- update examples
- fix clippy lints for Rust 1.97.0 ([#1213](https://github.com/0x676e67/wreq/pull/1213))
- Update .gitignore
- *(badssl)* retry on `badssl.com` connection reset errors ([#1207](https://github.com/0x676e67/wreq/pull/1207))
- update package description
- *(badssl)* add test case for wrong host on BadSSL ([#1202](https://github.com/0x676e67/wreq/pull/1202))
- add single-threaded benchmark for `cyper` HTTP Client ([#1195](https://github.com/0x676e67/wreq/pull/1195))

</blockquote>

</p></details>

---

This PR is managed with [release-plz](https://github.com/release-plz/release-plz/).