### PR TITLE
chore: release v0.16.0

### DIFF
--- a/.github/.release-plz.toml
+++ b/.github/.release-plz.toml
@@ -2,6 +2,8 @@
 # set the path of all the crates to the changelog to the root of the repository
 changelog_path = "./RELEASE.md"
 release_always = false
+# Tag CI runs the full checks before publishing to crates.io.
+publish = false
 # Tag CI creates GitHub releases with auto-generated notes.
 git_release_enable = false
 git_tag_enable = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wreq"
-version = "6.0.0-rc.31"
+version = "6.0.0-rc.32"
 description = "An ergonomic, privacy-aware Rust HTTP Client"
 keywords = ["http", "client", "websocket", "ja3", "ja4"]
 categories = ["web-programming::http-client"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wreq"
-version = "6.0.0-rc.32"
+version = "0.16.0"
 description = "An ergonomic, privacy-aware Rust HTTP Client"
 keywords = ["http", "client", "websocket", "ja3", "ja4"]
 categories = ["web-programming::http-client"]

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.0.0-rc.32](https://github.com/0x676e67/wreq/compare/v6.0.0-rc.31...v6.0.0-rc.32) - 2026-08-22
+
+### Fixed
+
+- *(ci)* use default Cargo Dependabot strategy
+
+### Other
+
+- *(deps)* update compio to 0.19.2 ([#1255](https://github.com/0x676e67/wreq/pull/1255))
+- Modify Dependabot settings for Cargo
+- *(msrv)* update to Rust 1.98 ([#1249](https://github.com/0x676e67/wreq/pull/1249))
+
 ## [6.0.0-rc.31](https://github.com/0x676e67/wreq/compare/v6.0.0-rc.29...v6.0.0-rc.31) - 2026-08-18
 
 ### Added

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [6.0.0-rc.32](https://github.com/0x676e67/wreq/compare/v6.0.0-rc.31...v6.0.0-rc.32) - 2026-08-22
+## [0.16.0](https://github.com/0x676e67/wreq/compare/v6.0.0-rc.31...v0.16.0) - 2026-08-23
+
+This release starts the new 0.x version line. The 6.0.0 RC line is no longer
+updated; users of those prereleases need to migrate to 0.16.x.
 
 ### Fixed
 


### PR DESCRIPTION


## 🤖 New release

* `wreq`: 6.0.0-rc.31 -> 0.16.0 (⚠ API breaking changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.16.0](https://github.com/0x676e67/wreq/compare/v6.0.0-rc.31...v0.16.0) - 2026-08-23

This release starts the new 0.x version line. The 6.0.0 RC line is no longer updated; users of those prereleases need to migrate to 0.16.x.

### Fixed

- *(ci)* use default Cargo Dependabot strategy

### Other

- *(deps)* update compio to 0.19.2 ([#1255](https://github.com/0x676e67/wreq/pull/1255))
- Modify Dependabot settings for Cargo
- *(msrv)* update to Rust 1.98 ([#1249](https://github.com/0x676e67/wreq/pull/1249))

</blockquote>

</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/) and adjusted for the 0.x version-line migration.