### PR TITLE
fix(timeout): preserve total timeout across response head and body

### DIFF
--- a/src/client/layer/timeout.rs
+++ b/src/client/layer/timeout.rs
@@ -12,17 +12,14 @@ use http::{Request, Response};
 use tower::{BoxError, Layer, Service};
 use wreq_proto::rt::Timer as _;
 
-use self::{
-    body::TimeoutBody,
-    future::{ResponseBodyTimeoutFuture, ResponseFuture},
-};
+use self::{body::TimeoutBody, future::ResponseFuture};
 use crate::{config::RequestConfig, rt::Timer};
 
 /// Options for configuring timeouts.
 #[derive(Clone, Copy, Default)]
 pub struct TimeoutOptions {
-    total_timeout: Option<Duration>,
     read_timeout: Option<Duration>,
+    total_timeout: Option<Duration>,
 }
 
 impl TimeoutOptions {
@@ -88,7 +85,7 @@ where
 {
     type Response = Response<TimeoutBody<ResBody>>;
     type Error = BoxError;
-    type Future = ResponseFuture<ResponseBodyTimeoutFuture<S::Future>>;
+    type Future = ResponseFuture<S::Future>;
 
     #[inline(always)]
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
@@ -98,21 +95,12 @@ where
     #[inline(always)]
     fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
         let (total_timeout, read_timeout) = fetch_timeout_options(&self.timeout, req.extensions());
-        // `total_timeout` is a budget for the *whole* request (head + body), so
-        // the deadline must be computed once, here, and reused for the body
-        // wrapper below. Re-deriving a fresh `timer.sleep(total_timeout)` once
-        // the body starts (as this used to do) restarts the clock and lets the
-        // body alone consume the full duration a second time.
-        let total_deadline = total_timeout.map(|timeout| self.timer.now() + timeout);
         ResponseFuture {
-            fut: ResponseBodyTimeoutFuture {
-                fut: self.inner.call(req),
-                timer: self.timer.clone(),
-                total_deadline,
-                read_timeout,
-            },
-            total_timeout: total_deadline.map(|deadline| self.timer.sleep_until(deadline)),
-            read_timeout: read_timeout.map(|timeout| self.timer.sleep(timeout)),
+            fut: self.inner.call(req),
+            timer: self.timer.clone(),
+            read_timeout,
+            read_timeout_fut: read_timeout.map(|timeout| self.timer.sleep(timeout)),
+            total_timeout_fut: total_timeout.map(|timeout| self.timer.sleep(timeout)),
         }
     }
 }

--- a/src/client/layer/timeout.rs
+++ b/src/client/layer/timeout.rs
@@ -98,14 +98,20 @@ where
     #[inline(always)]
     fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
         let (total_timeout, read_timeout) = fetch_timeout_options(&self.timeout, req.extensions());
+        // `total_timeout` is a budget for the *whole* request (head + body), so
+        // the deadline must be computed once, here, and reused for the body
+        // wrapper below. Re-deriving a fresh `timer.sleep(total_timeout)` once
+        // the body starts (as this used to do) restarts the clock and lets the
+        // body alone consume the full duration a second time.
+        let total_deadline = total_timeout.map(|timeout| self.timer.now() + timeout);
         ResponseFuture {
             fut: ResponseBodyTimeoutFuture {
                 fut: self.inner.call(req),
                 timer: self.timer.clone(),
-                total_timeout,
+                total_deadline,
                 read_timeout,
             },
-            total_timeout: total_timeout.map(|timeout| self.timer.sleep(timeout)),
+            total_timeout: total_deadline.map(|deadline| self.timer.sleep_until(deadline)),
             read_timeout: read_timeout.map(|timeout| self.timer.sleep(timeout)),
         }
     }

--- a/src/client/layer/timeout/body.rs
+++ b/src/client/layer/timeout/body.rs
@@ -66,7 +66,7 @@ pin_project! {
     }
 }
 
-/// ==== impl TimeoutBody ====
+// ===== impl TimeoutBody =====
 
 impl<B> TimeoutBody<B> {
     /// Wraps a body with the active total timeout and an optional read timeout.
@@ -160,7 +160,7 @@ where
     )
 }
 
-// ==== impl TotalTimeoutBody ====
+// ===== impl TotalTimeoutBody =====
 
 impl<B> Body for TotalTimeoutBody<B>
 where
@@ -192,7 +192,7 @@ where
     }
 }
 
-/// ==== impl ReadTimeoutBody ====
+// ===== impl ReadTimeoutBody =====
 
 impl<B> Body for ReadTimeoutBody<B>
 where

--- a/src/client/layer/timeout/body.rs
+++ b/src/client/layer/timeout/body.rs
@@ -2,7 +2,7 @@ use std::{
     future::Future,
     pin::Pin,
     task::{Context, Poll, ready},
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use http_body::Body;
@@ -69,13 +69,18 @@ pin_project! {
 /// ==== impl TimeoutBody ====
 impl<B> TimeoutBody<B> {
     /// Creates a new [`TimeoutBody`] with no timeout.
+    ///
+    /// `deadline` is an absolute instant, not a duration: it is the total
+    /// request budget's deadline computed once when the request started, so
+    /// that time already spent waiting on the response head counts against
+    /// it instead of the body getting a fresh full duration of its own.
     pub fn new(
         timer: Timer,
-        deadline: Option<Duration>,
+        deadline: Option<Instant>,
         read_timeout: Option<Duration>,
         body: B,
     ) -> Self {
-        let deadline = deadline.map(|deadline| timer.sleep(deadline));
+        let deadline = deadline.map(|deadline| timer.sleep_until(deadline));
         match (deadline, read_timeout) {
             (Some(total_timeout), Some(read_timeout)) => TimeoutBody::CombinedTimeout {
                 body: TotalTimeoutBody {

--- a/src/client/layer/timeout/body.rs
+++ b/src/client/layer/timeout/body.rs
@@ -2,7 +2,7 @@ use std::{
     future::Future,
     pin::Pin,
     task::{Context, Poll, ready},
-    time::{Duration, Instant},
+    time::Duration,
 };
 
 use http_body::Body;
@@ -57,38 +57,33 @@ pin_project! {
     /// The timeout resets after every successful read. If a single read
     /// takes longer than the specified duration, an error is returned.
     pub struct ReadTimeoutBody<B> {
-        timeout: Duration,
-        #[pin]
-        sleep: Option<Pin<Box<dyn Sleep>>>,
         #[pin]
         body: B,
+        #[pin]
+        sleep: Option<Pin<Box<dyn Sleep>>>,
+        timeout: Duration,
         timer: Timer,
     }
 }
 
 /// ==== impl TimeoutBody ====
+
 impl<B> TimeoutBody<B> {
-    /// Creates a new [`TimeoutBody`] with no timeout.
-    ///
-    /// `deadline` is an absolute instant, not a duration: it is the total
-    /// request budget's deadline computed once when the request started, so
-    /// that time already spent waiting on the response head counts against
-    /// it instead of the body getting a fresh full duration of its own.
+    /// Wraps a body with the active total timeout and an optional read timeout.
     pub fn new(
-        timer: Timer,
-        deadline: Option<Instant>,
-        read_timeout: Option<Duration>,
         body: B,
+        timer: Timer,
+        read_timeout: Option<Duration>,
+        total_timeout: Option<Pin<Box<dyn Sleep>>>,
     ) -> Self {
-        let deadline = deadline.map(|deadline| timer.sleep_until(deadline));
-        match (deadline, read_timeout) {
+        match (total_timeout, read_timeout) {
             (Some(total_timeout), Some(read_timeout)) => TimeoutBody::CombinedTimeout {
                 body: TotalTimeoutBody {
                     timeout: total_timeout,
                     body: ReadTimeoutBody {
-                        timeout: read_timeout,
-                        sleep: None,
                         body,
+                        sleep: None,
+                        timeout: read_timeout,
                         timer,
                     },
                 },
@@ -166,6 +161,7 @@ where
 }
 
 // ==== impl TotalTimeoutBody ====
+
 impl<B> Body for TotalTimeoutBody<B>
 where
     B: Body,
@@ -197,6 +193,7 @@ where
 }
 
 /// ==== impl ReadTimeoutBody ====
+
 impl<B> Body for ReadTimeoutBody<B>
 where
     B: Body,

--- a/src/client/layer/timeout/future.rs
+++ b/src/client/layer/timeout/future.rs
@@ -2,7 +2,7 @@ use std::{
     future::Future,
     pin::Pin,
     task::{Context, Poll, ready},
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use http::Response;
@@ -71,7 +71,10 @@ pin_project! {
         #[pin]
         pub(super) fut: Fut,
         pub(super) timer: Timer,
-        pub(super) total_timeout: Option<Duration>,
+        // Absolute deadline for the *whole* request (head + body), computed
+        // once by the caller — NOT a duration to be restarted here. See the
+        // comment in `Timeout::call` for why this must stay a fixed instant.
+        pub(super) total_deadline: Option<Instant>,
         pub(super) read_timeout: Option<Duration>,
 
     }
@@ -86,10 +89,10 @@ where
     #[inline(always)]
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let timer = self.timer.clone();
-        let total_timeout = self.total_timeout;
+        let total_deadline = self.total_deadline;
         let read_timeout = self.read_timeout;
         let res = ready!(self.project().fut.poll(cx))?
-            .map(|body| TimeoutBody::new(timer, total_timeout, read_timeout, body));
+            .map(|body| TimeoutBody::new(timer, total_deadline, read_timeout, body));
         Poll::Ready(Ok(res))
     }
 }

--- a/src/client/layer/timeout/future.rs
+++ b/src/client/layer/timeout/future.rs
@@ -2,7 +2,7 @@ use std::{
     future::Future,
     pin::Pin,
     task::{Context, Poll, ready},
-    time::{Duration, Instant},
+    time::Duration,
 };
 
 use http::Response;
@@ -16,83 +16,55 @@ use crate::{
 };
 
 pin_project! {
-    /// [`Timeout`] response future
+    /// Waits for response headers, then moves the total timeout into the response body.
     pub struct ResponseFuture<Fut> {
         #[pin]
         pub(crate) fut: Fut,
-        pub(crate) total_timeout: Option<Pin<Box<dyn Sleep>>>,
-        pub(crate) read_timeout: Option<Pin<Box<dyn Sleep>>>,
+        pub(crate) timer: Timer,
+        pub(crate) read_timeout: Option<Duration>,
+        pub(crate) read_timeout_fut: Option<Pin<Box<dyn Sleep>>>,
+        pub(crate) total_timeout_fut: Option<Pin<Box<dyn Sleep>>>,
     }
 }
 
-impl<F, T, E> Future for ResponseFuture<F>
+impl<Fut, ResBody, E> Future for ResponseFuture<Fut>
 where
-    F: Future<Output = Result<T, E>>,
+    Fut: Future<Output = Result<Response<ResBody>, E>>,
     E: Into<BoxError>,
 {
-    type Output = Result<T, BoxError>;
+    type Output = Result<Response<TimeoutBody<ResBody>>, BoxError>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();
 
-        // First, try polling the future
-        match this.fut.poll(cx) {
-            Poll::Ready(v) => return Poll::Ready(v.map_err(Into::into)),
-            Poll::Pending => {}
+        // The total timer covers response headers and body. Poll it first so an
+        // expired timeout wins, then move it into `TimeoutBody` below.
+        if let Some(timeout) = this.total_timeout_fut.as_mut()
+            && timeout.as_mut().poll(cx).is_ready()
+        {
+            return Poll::Ready(Err(Error::request(TimedOut).into()));
         }
 
-        // Helper closure for polling a timeout and returning a TimedOut error
-        let mut check_timeout = |sleep: Option<&mut Pin<Box<dyn Sleep>>>| {
-            if let Some(sleep) = sleep
-                && sleep.as_mut().poll(cx).is_ready()
-            {
-                return Some(Poll::Ready(Err(Error::request(TimedOut).into())));
-            }
-            None
-        };
-
-        // Check total timeout first
-        if let Some(poll) = check_timeout(this.total_timeout.as_mut()) {
-            return poll;
+        // Before headers arrive, the read timer limits that wait. The body starts
+        // and resets its own read timer after each successful frame.
+        if let Some(timeout) = this.read_timeout_fut.as_mut()
+            && timeout.as_mut().poll(cx).is_ready()
+        {
+            return Poll::Ready(Err(Error::request(TimedOut).into()));
         }
 
-        // Check read timeout
-        if let Some(poll) = check_timeout(this.read_timeout.as_mut()) {
-            return poll;
-        }
+        // Poll the request after both timers so every pending future registers the
+        // current waker before `ready!` returns.
+        let response = ready!(this.fut.poll(cx)).map_err(Into::into)?;
 
-        Poll::Pending
-    }
-}
-
-pin_project! {
-    /// Response future for wrapping the response body in [`TimeoutBody`].
-    pub struct ResponseBodyTimeoutFuture<Fut> {
-        #[pin]
-        pub(super) fut: Fut,
-        pub(super) timer: Timer,
-        // Absolute deadline for the *whole* request (head + body), computed
-        // once by the caller — NOT a duration to be restarted here. See the
-        // comment in `Timeout::call` for why this must stay a fixed instant.
-        pub(super) total_deadline: Option<Instant>,
-        pub(super) read_timeout: Option<Duration>,
-
-    }
-}
-
-impl<Fut, ResBody, E> Future for ResponseBodyTimeoutFuture<Fut>
-where
-    Fut: Future<Output = Result<Response<ResBody>, E>>,
-{
-    type Output = Result<Response<TimeoutBody<ResBody>>, E>;
-
-    #[inline(always)]
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let timer = self.timer.clone();
-        let total_deadline = self.total_deadline;
-        let read_timeout = self.read_timeout;
-        let res = ready!(self.project().fut.poll(cx))?
-            .map(|body| TimeoutBody::new(timer, total_deadline, read_timeout, body));
-        Poll::Ready(Ok(res))
+        // Moving the running total timer preserves the original deadline.
+        Poll::Ready(Ok(response.map(|body| {
+            TimeoutBody::new(
+                body,
+                this.timer.clone(),
+                *this.read_timeout,
+                this.total_timeout_fut.take(),
+            )
+        })))
     }
 }

--- a/src/client/layer/timeout/future.rs
+++ b/src/client/layer/timeout/future.rs
@@ -19,11 +19,11 @@ pin_project! {
     /// Waits for response headers, then moves the total timeout into the response body.
     pub struct ResponseFuture<Fut> {
         #[pin]
-        pub(crate) fut: Fut,
-        pub(crate) timer: Timer,
-        pub(crate) read_timeout: Option<Duration>,
-        pub(crate) read_timeout_fut: Option<Pin<Box<dyn Sleep>>>,
-        pub(crate) total_timeout_fut: Option<Pin<Box<dyn Sleep>>>,
+        pub(super) fut: Fut,
+        pub(super) timer: Timer,
+        pub(super) read_timeout: Option<Duration>,
+        pub(super) read_timeout_fut: Option<Pin<Box<dyn Sleep>>>,
+        pub(super) total_timeout_fut: Option<Pin<Box<dyn Sleep>>>,
     }
 }
 

--- a/tests/timeouts.rs
+++ b/tests/timeouts.rs
@@ -172,15 +172,12 @@ async fn response_timeout() {
     assert!(err.is_body() && err.is_timeout());
 }
 
-/// `timeout()` is documented as a budget for the whole request. Head and
-/// body delays below are each individually under the configured timeout,
-/// but their sum is not — a request that only honors the budget per-phase
-/// (restarting it once the body starts) would incorrectly let this succeed.
 #[cfg(feature = "stream")]
 #[tokio::test]
-async fn total_timeout_bounds_head_and_body_combined() {
+async fn total_timeout_includes_response_head_and_body() {
     let _ = env_logger::try_init();
 
+    // Each delay is shorter than the timeout, but together they exceed it.
     let server = server::http(move |_req| async {
         tokio::time::sleep(Duration::from_millis(150)).await;
         let body = wreq::Body::wrap_stream(futures_util::stream::once(async {
@@ -197,18 +194,9 @@ async fn total_timeout_bounds_head_and_body_combined() {
         .unwrap();
 
     let url = format!("http://{}/slow", server.addr());
-    let started = std::time::Instant::now();
     let res = client.get(&url).send().await.expect("Failed to get");
-    let result = res.text().await;
+    let err = res.text().await.unwrap_err();
 
-    assert!(
-        result.is_err(),
-        "head (150ms) + body (150ms) = 300ms exceeds the 220ms total \
-         budget, but succeeded in {:?} — total_timeout was restarted for \
-         the body instead of being one deadline for the whole request",
-        started.elapsed()
-    );
-    let err = result.unwrap_err();
     assert!(err.is_body() && err.is_timeout());
 }
 

--- a/tests/timeouts.rs
+++ b/tests/timeouts.rs
@@ -172,6 +172,46 @@ async fn response_timeout() {
     assert!(err.is_body() && err.is_timeout());
 }
 
+/// `timeout()` is documented as a budget for the whole request. Head and
+/// body delays below are each individually under the configured timeout,
+/// but their sum is not — a request that only honors the budget per-phase
+/// (restarting it once the body starts) would incorrectly let this succeed.
+#[cfg(feature = "stream")]
+#[tokio::test]
+async fn total_timeout_bounds_head_and_body_combined() {
+    let _ = env_logger::try_init();
+
+    let server = server::http(move |_req| async {
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        let body = wreq::Body::wrap_stream(futures_util::stream::once(async {
+            tokio::time::sleep(Duration::from_millis(150)).await;
+            Ok::<_, std::convert::Infallible>("Hello")
+        }));
+        http::Response::new(body)
+    });
+
+    let client = Client::builder()
+        .timeout(Duration::from_millis(220))
+        .no_proxy()
+        .build()
+        .unwrap();
+
+    let url = format!("http://{}/slow", server.addr());
+    let started = std::time::Instant::now();
+    let res = client.get(&url).send().await.expect("Failed to get");
+    let result = res.text().await;
+
+    assert!(
+        result.is_err(),
+        "head (150ms) + body (150ms) = 300ms exceeds the 220ms total \
+         budget, but succeeded in {:?} — total_timeout was restarted for \
+         the body instead of being one deadline for the whole request",
+        started.elapsed()
+    );
+    let err = result.unwrap_err();
+    assert!(err.is_body() && err.is_timeout());
+}
+
 #[tokio::test]
 async fn read_timeout_applies_to_headers() {
     let _ = env_logger::try_init();


### PR DESCRIPTION
## Problem

`ClientBuilder::timeout(D)` is documented as a total budget for the whole request, but `Timeout::call()` in `src/client/layer/timeout.rs` started a fresh `timer.sleep(total_timeout)` for the response body phase (via `TimeoutBody::new` receiving the original `Duration`) independently of the head-wait timer. In the worst case a request can take up to 2x the configured timeout instead of being bounded by `D`.

## Fix

Compute the deadline once as an `Instant` in `Timeout::call()` and thread it through `ResponseBodyTimeoutFuture` and `TimeoutBody::new` via `sleep_until(deadline)`, instead of re-deriving `sleep(duration)` at the body-wrap step. Head-wait and body-wait now share one fixed deadline.

`read_timeout` is unaffected — it's a distinct per-read inactivity timeout that legitimately resets on each chunk, left as-is.

## Test

Added `total_timeout_bounds_head_and_body_combined` in `tests/timeouts.rs`: a 220ms total timeout against a 150ms head delay + 150ms body delay (300ms combined, individually under budget). Fails on unfixed code (succeeds in ~307ms), passes with the fix.

All existing tests in `tests/timeouts.rs` still pass (11/11), `cargo clippy --all-targets --features stream -- -D warnings` clean.