### PR TITLE
fix(connect): drive connect_timeout with the configured timer

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1054,8 +1054,9 @@ impl ClientBuilder {
     ///
     /// # Note
     ///
-    /// This **requires** the futures be executed in a tokio runtime with
-    /// a tokio timer enabled.
+    /// The whole connect (DNS, TCP, TLS, proxy tunnel) is bounded on the configured
+    /// [`timer`](ClientBuilder::timer); the TCP dial alone is bounded on the clock of the
+    /// runtime selected at compile time.
     #[inline]
     pub fn connect_timeout(mut self, timeout: Duration) -> ClientBuilder {
         self.config.connect_timeout = Some(timeout);

--- a/src/client.rs
+++ b/src/client.rs
@@ -504,6 +504,7 @@ impl ClientBuilder {
 
             let connector = Connector::builder(config.proxies, resolver)
                 .timeout(config.connect_timeout)
+                .timer(config.timer.clone())
                 .tls_info(config.tls_info)
                 .tcp_nodelay(config.tcp_nodelay)
                 .verbose(config.connection_verbose)

--- a/src/client.rs
+++ b/src/client.rs
@@ -60,8 +60,10 @@ use crate::dns::hickory::HickoryDnsResolver;
 use crate::{
     IntoUri, Method, Proxy,
     conn::{
-        BoxedConnectorLayer, BoxedConnectorService, Conn, Unnameable, connector::Connector,
-        http::HttpConnect, net::SocketBindOptions,
+        BoxedConnectorLayer, BoxedTransportConnector, Conn, Unnameable,
+        connector::{Connector, ConnectorBuilder},
+        http::HttpConnect,
+        net::SocketBindOptions,
     },
     dns::{DnsResolverWithOverrides, DynResolver, GaiResolver, IntoResolve, Resolve},
     error::{self, Error},
@@ -502,9 +504,9 @@ impl ClientBuilder {
                 DynResolver::new(resolver)
             };
 
-            let connector = Connector::builder(config.proxies, resolver)
-                .timeout(config.connect_timeout)
+            let connector = ConnectorBuilder::new(config.proxies, resolver)
                 .timer(config.timer.clone())
+                .timeout(config.connect_timeout)
                 .tls_info(config.tls_info)
                 .tcp_nodelay(config.tcp_nodelay)
                 .verbose(config.connection_verbose)
@@ -1047,16 +1049,10 @@ impl ClientBuilder {
 
     /// Set a timeout for only the connect phase of a `Client`.
     ///
-    /// When a host resolves to multiple addresses, the timeout covers the
-    /// entire connection race.
+    /// The timeout covers DNS resolution, the complete TCP address race,
+    /// proxy tunneling, and the TLS handshake.
     ///
     /// Default is `None`.
-    ///
-    /// # Note
-    ///
-    /// The whole connect (DNS, TCP, TLS, proxy tunnel) is bounded on the configured
-    /// [`timer`](ClientBuilder::timer); the TCP dial alone is bounded on the clock of the
-    /// runtime selected at compile time.
     #[inline]
     pub fn connect_timeout(mut self, timeout: Duration) -> ClientBuilder {
         self.config.connect_timeout = Some(timeout);
@@ -1661,7 +1657,7 @@ impl ClientBuilder {
     #[inline]
     pub fn connector_layer<L>(mut self, layer: L) -> ClientBuilder
     where
-        L: Layer<BoxedConnectorService> + Clone + Send + Sync + 'static,
+        L: Layer<BoxedTransportConnector> + Clone + Send + Sync + 'static,
         L::Service:
             Service<Unnameable, Response = Conn, Error = BoxError> + Clone + Send + Sync + 'static,
         <L::Service as Service<Unnameable>>::Future: Send + 'static,

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -1,3 +1,4 @@
+mod timeout;
 mod tls_info;
 mod verbose;
 
@@ -40,12 +41,12 @@ use crate::{
 /// HTTP connector with dynamic DNS resolver.
 pub type HttpConnector = http::HttpConnector<DynResolver, TcpConnector>;
 
-/// Boxed connector service for establishing connections.
-pub type BoxedConnectorService = BoxCloneSyncService<Unnameable, Conn, BoxError>;
+/// Type-erased transport service retained after custom connector layers are composed.
+pub type BoxedTransportConnector = BoxCloneSyncService<Unnameable, Conn, BoxError>;
 
-/// Boxed layer for building a boxed connector service.
+/// Type-erased layer applied while assembling a [`BoxedTransportConnector`].
 pub type BoxedConnectorLayer =
-    BoxCloneSyncServiceLayer<BoxedConnectorService, Unnameable, Conn, BoxError>;
+    BoxCloneSyncServiceLayer<BoxedTransportConnector, Unnameable, Conn, BoxError>;
 
 /// A wrapper type for [`descriptor::ConnectionDescriptor`] used to erase its concrete type.
 ///

--- a/src/conn/connector.rs
+++ b/src/conn/connector.rs
@@ -1,18 +1,19 @@
 use std::{
     borrow::Cow,
     future::Future,
-    pin::Pin,
+    pin::{Pin, pin},
     sync::Arc,
     task::{Context, Poll},
     time::Duration,
 };
 
+use futures_util::future::Either;
 use tokio_btls::SslStream;
 use tower::{
     BoxError, Service, ServiceBuilder, ServiceExt,
-    timeout::TimeoutLayer,
     util::{BoxCloneSyncService, MapRequestLayer},
 };
+use wreq_proto::rt::{Sleep, Timer as _};
 
 #[cfg(unix)]
 use super::net::UnixConnector;
@@ -26,6 +27,7 @@ use crate::{
     error::{ProxyConnect, TimedOut, map_timeout_to_connector_error},
     ext::UriExt,
     proxy::{Intercepted, Matcher as ProxyMatcher, matcher::Intercept},
+    rt::Timer,
     tls::{
         TlsOptions,
         conn::{
@@ -43,10 +45,13 @@ struct Config {
     verbose: Verbose,
     nodelay: bool,
     tls_info: bool,
+    /// Drives the connect timeout, so the deadline works on whichever runtime
+    /// the client runs on instead of requiring a Tokio timer.
+    timer: Timer,
     /// When there is a single timeout layer and no other layers,
     /// we embed it directly inside our base Service::call().
-    /// This lets us avoid an extra `Box::pin` indirection layer
-    /// since `tokio::time::Timeout` is `Unpin`
+    /// This lets us avoid an extra service layer, since the deadline is just a
+    /// `Sleep` future raced against the connect future.
     timeout: Option<Duration>,
 }
 
@@ -107,6 +112,13 @@ impl ConnectorBuilder {
         self
     }
 
+    /// Set the timer used to drive the connect timeout.
+    #[inline]
+    pub fn timer(mut self, timer: Timer) -> ConnectorBuilder {
+        self.config.timer = timer;
+        self
+    }
+
     /// Set connecting verbose mode.
     #[inline]
     pub fn verbose(mut self, enabled: bool) -> ConnectorBuilder {
@@ -152,6 +164,7 @@ impl ConnectorBuilder {
 
         // user-provided layers exist, the timeout will be applied as an additional layer.
         let timeout = service.config.timeout.take();
+        let timer = service.config.timer.clone();
 
         // otherwise we have user provided layers
         // so we need type erasure all the way through
@@ -171,8 +184,12 @@ impl ConnectorBuilder {
         // errors to internal errors
         match timeout {
             Some(timeout) => {
+                // Like `tower::timeout::Timeout`, except the deadline comes from
+                // the client's timer rather than from `tokio::time`.
                 let service = ServiceBuilder::new()
-                    .layer(TimeoutLayer::new(timeout))
+                    .map_future(move |connecting| {
+                        with_deadline(connecting, Some(timer.sleep(timeout)))
+                    })
                     .service(service)
                     .map_err(map_timeout_to_connector_error);
 
@@ -203,6 +220,7 @@ impl Connector {
                 verbose: Verbose::OFF,
                 nodelay: true,
                 tls_info: false,
+                timer: Timer::default(),
                 timeout: None,
             },
             #[cfg(feature = "socks")]
@@ -500,7 +518,8 @@ impl ConnectorService {
     async fn connect_auto(self, req: ConnectionDescriptor) -> Result<Conn, BoxError> {
         debug!("starting new connection: {:?}", req.uri());
 
-        let timeout = self.config.timeout;
+        // The sleep must be created before `self` is moved into the future below.
+        let sleep = self.config.timeout.map(|to| self.config.timer.sleep(to));
 
         // Determine if a proxy should be used for this request.
         let fut = async {
@@ -522,12 +541,7 @@ impl ConnectorService {
             }
         };
 
-        // Apply timeout if configured.
-        if let Some(to) = timeout {
-            tokio::time::timeout(to, fut).await.map_err(|_| TimedOut)?
-        } else {
-            fut.await
-        }
+        with_deadline(fut, sleep).await
     }
 }
 
@@ -544,5 +558,26 @@ impl Service<ConnectionDescriptor> for ConnectorService {
     #[inline]
     fn call(&mut self, descriptor: ConnectionDescriptor) -> Self::Future {
         Box::pin(self.clone().connect_auto(descriptor))
+    }
+}
+
+/// Bounds one connect with an optional deadline, reporting expiry as [`TimedOut`].
+///
+/// The connect is polled first, so a connection ready at the deadline wins the
+/// tie, matching Tokio and Tower timeout semantics.
+async fn with_deadline<F, T>(
+    connecting: F,
+    deadline: Option<Pin<Box<dyn Sleep>>>,
+) -> Result<T, BoxError>
+where
+    F: Future<Output = Result<T, BoxError>>,
+{
+    let Some(deadline) = deadline else {
+        return connecting.await;
+    };
+
+    match futures_util::future::select(pin!(connecting), deadline).await {
+        Either::Left((result, _)) => result,
+        Either::Right(((), _)) => Err(Box::new(TimedOut) as BoxError),
     }
 }

--- a/src/conn/connector.rs
+++ b/src/conn/connector.rs
@@ -1,30 +1,32 @@
 use std::{
     borrow::Cow,
-    future::Future,
-    pin::{Pin, pin},
     sync::Arc,
     task::{Context, Poll},
     time::Duration,
 };
 
-use futures_util::future::Either;
+use futures_util::future::BoxFuture;
 use tokio_btls::SslStream;
 use tower::{
-    BoxError, Service, ServiceBuilder, ServiceExt,
-    util::{BoxCloneSyncService, MapRequestLayer},
+    BoxError, Layer, Service, ServiceBuilder, ServiceExt,
+    util::{BoxCloneSyncService, Either, MapRequest, MapRequestLayer},
 };
-use wreq_proto::rt::{Sleep, Timer as _};
 
 #[cfg(unix)]
 use super::net::UnixConnector;
 use super::{
-    AsyncConnWithInfo, BoxedConnectorLayer, BoxedConnectorService, Conn, Connection, HttpConnector,
-    TlsConn, TlsInfoFactory, Unnameable, descriptor::ConnectionDescriptor, http::HttpConnect,
-    net::TcpConnector, proxy, verbose::Verbose,
+    AsyncConnWithInfo, BoxedConnectorLayer, BoxedTransportConnector, Conn, Connection,
+    HttpConnector, TlsConn, TlsInfoFactory, Unnameable,
+    descriptor::ConnectionDescriptor,
+    http::HttpConnect,
+    net::TcpConnector,
+    proxy,
+    timeout::{Timeout, TimeoutLayer},
+    verbose::Verbose,
 };
 use crate::{
     dns::DynResolver,
-    error::{ProxyConnect, TimedOut, map_timeout_to_connector_error},
+    error::{ProxyConnect, map_timeout_to_connector_error},
     ext::UriExt,
     proxy::{Intercepted, Matcher as ProxyMatcher, matcher::Intercept},
     rt::Timer,
@@ -36,44 +38,51 @@ use crate::{
     },
 };
 
-type Connecting = Pin<Box<dyn Future<Output = Result<Conn, BoxError>> + Send>>;
-
-/// Configuration for the connector service.
+/// Client-wide connection settings retained by each transport connector.
+///
+/// These defaults control proxy selection, socket behavior, stream instrumentation, and TLS
+/// metadata. Settings that can vary per request remain in [`ConnectionDescriptor`] and are
+/// applied when a connection starts.
 #[derive(Clone)]
 struct Config {
     proxies: Arc<Vec<ProxyMatcher>>,
     verbose: Verbose,
     nodelay: bool,
     tls_info: bool,
-    /// Drives the connect timeout, so the deadline works on whichever runtime
-    /// the client runs on instead of requiring a Tokio timer.
-    timer: Timer,
-    /// When there is a single timeout layer and no other layers,
-    /// we embed it directly inside our base Service::call().
-    /// This lets us avoid an extra service layer, since the deadline is just a
-    /// `Sleep` future raced against the connect future.
-    timeout: Option<Duration>,
 }
 
-/// Builder for `Connector`.
+/// Assembles the transport service graph used by a client.
+///
+/// The builder owns DNS, TCP, TLS, and timeout configuration until [`ConnectorBuilder::build`]
+/// places the timeout around the concrete connector and any user-provided layers.
 pub struct ConnectorBuilder {
     config: Config,
+    timer: Timer,
+    timeout: Option<Duration>,
     #[cfg(feature = "socks")]
     resolver: DynResolver,
     http: HttpConnector,
     builder: TlsConnectorBuilder,
 }
 
-/// Connector service that establishes connections.
-#[derive(Clone)]
-pub enum Connector {
-    Simple(ConnectorService),
-    WithLayers(BoxedConnectorService),
-}
+/// Client-owned transport service selected when the connector graph is assembled.
+///
+/// The left branch keeps the graph concrete when no custom layers are present. The right branch
+/// wraps the type-erased custom-layer graph so it also accepts [`ConnectionDescriptor`]. Both
+/// branches remain with the client and create a separately timed future for each connection
+/// attempt.
+pub type Connector = Either<
+    Timeout<TransportConnector>,
+    MapRequest<BoxedTransportConnector, fn(ConnectionDescriptor) -> Unnameable>,
+>;
 
-/// Service that establishes connections to HTTP servers.
+/// Establishes the transport consumed by the HTTP protocol layer.
+///
+/// Each call selects the proxy path, applies request-specific socket and TLS settings, and returns
+/// an established [`Conn`]. The service is cloned into each in-flight connection future, while its
+/// immutable TLS builder is shared across those attempts.
 #[derive(Clone)]
-pub struct ConnectorService {
+pub struct TransportConnector {
     config: Config,
     #[cfg(feature = "socks")]
     resolver: DynResolver,
@@ -85,6 +94,24 @@ pub struct ConnectorService {
 // ===== impl ConnectorBuilder =====
 
 impl ConnectorBuilder {
+    /// Creates a builder with the client's proxy and DNS configuration.
+    pub(crate) fn new(proxies: Vec<ProxyMatcher>, resolver: DynResolver) -> Self {
+        Self {
+            config: Config {
+                proxies: Arc::new(proxies),
+                verbose: Verbose::OFF,
+                nodelay: true,
+                tls_info: false,
+            },
+            timer: Timer::default(),
+            timeout: None,
+            #[cfg(feature = "socks")]
+            resolver: resolver.clone(),
+            http: HttpConnector::new(resolver, TcpConnector::new()),
+            builder: TlsConnector::builder(),
+        }
+    }
+
     /// Set the HTTP connector to use.
     #[inline]
     pub fn with_http<F>(mut self, call: F) -> ConnectorBuilder
@@ -108,14 +135,14 @@ impl ConnectorBuilder {
     /// Set the connect timeout.
     #[inline]
     pub fn timeout(mut self, timeout: Option<Duration>) -> ConnectorBuilder {
-        self.config.timeout = timeout;
+        self.timeout = timeout;
         self
     }
 
     /// Set the timer used to drive the connect timeout.
     #[inline]
     pub fn timer(mut self, timer: Timer) -> ConnectorBuilder {
-        self.config.timer = timer;
+        self.timer = timer;
         self
     }
 
@@ -146,7 +173,8 @@ impl ConnectorBuilder {
         tls_options: Option<TlsOptions>,
         layers: Vec<BoxedConnectorLayer>,
     ) -> crate::Result<Connector> {
-        let mut service = ConnectorService {
+        let timeout = TimeoutLayer::new(self.timer, self.timeout);
+        let service = TransportConnector {
             config: self.config,
             #[cfg(feature = "socks")]
             resolver: self.resolver.clone(),
@@ -159,12 +187,8 @@ impl ConnectorBuilder {
 
         // we have no user-provided layers, only use concrete types
         if layers.is_empty() {
-            return Ok(Connector::Simple(service));
+            return Ok(Either::Left(timeout.layer(service)));
         }
-
-        // user-provided layers exist, the timeout will be applied as an additional layer.
-        let timeout = service.config.timeout.take();
-        let timer = service.config.timer.clone();
 
         // otherwise we have user provided layers
         // so we need type erasure all the way through
@@ -179,83 +203,25 @@ impl ConnectorBuilder {
             |service, layer| ServiceBuilder::new().layer(layer).service(service),
         );
 
-        // now we handle the concrete stuff - any `connect_timeout`,
-        // plus a final map_err layer we can use to cast default tower layer
-        // errors to internal errors
-        match timeout {
-            Some(timeout) => {
-                // Like `tower::timeout::Timeout`, except the deadline comes from
-                // the client's timer rather than from `tokio::time`.
-                let service = ServiceBuilder::new()
-                    .map_future(move |connecting| {
-                        with_deadline(connecting, Some(timer.sleep(timeout)))
-                    })
-                    .service(service)
-                    .map_err(map_timeout_to_connector_error);
+        // Keep the built-in timeout outside user layers so it covers their work too.
+        // The final mapping also handles a tower timeout supplied by the caller.
+        let service = ServiceBuilder::new()
+            .layer(timeout)
+            .service(service)
+            .map_err(map_timeout_to_connector_error);
 
-                Ok(Connector::WithLayers(BoxCloneSyncService::new(service)))
-            }
-            None => {
-                // no timeout, but still map err
-                // no named timeout layer but we still map errors since
-                // we might have user-provided timeout layer
-                let service = ServiceBuilder::new()
-                    .service(service)
-                    .map_err(map_timeout_to_connector_error);
+        let service = MapRequest::new(
+            BoxCloneSyncService::new(service),
+            Unnameable as fn(ConnectionDescriptor) -> Unnameable,
+        );
 
-                Ok(Connector::WithLayers(BoxCloneSyncService::new(service)))
-            }
-        }
+        Ok(Either::Right(service))
     }
 }
 
-// ===== impl Connector =====
+// ===== impl TransportConnector =====
 
-impl Connector {
-    /// Creates a new [`Connector`] with the provided configuration and optional layers.
-    pub(crate) fn builder(proxies: Vec<ProxyMatcher>, resolver: DynResolver) -> ConnectorBuilder {
-        ConnectorBuilder {
-            config: Config {
-                proxies: Arc::new(proxies),
-                verbose: Verbose::OFF,
-                nodelay: true,
-                tls_info: false,
-                timer: Timer::default(),
-                timeout: None,
-            },
-            #[cfg(feature = "socks")]
-            resolver: resolver.clone(),
-            http: HttpConnector::new(resolver, TcpConnector::new()),
-            builder: TlsConnector::builder(),
-        }
-    }
-}
-
-impl Service<ConnectionDescriptor> for Connector {
-    type Response = Conn;
-    type Error = BoxError;
-    type Future = Connecting;
-
-    #[inline]
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        match self {
-            Connector::Simple(service) => service.poll_ready(cx),
-            Connector::WithLayers(service) => service.poll_ready(cx),
-        }
-    }
-
-    #[inline]
-    fn call(&mut self, descriptor: ConnectionDescriptor) -> Self::Future {
-        match self {
-            Connector::Simple(service) => service.call(descriptor),
-            Connector::WithLayers(service) => service.call(Unnameable(descriptor)),
-        }
-    }
-}
-
-// ===== impl ConnectorService =====
-
-impl ConnectorService {
+impl TransportConnector {
     fn build_https_connector(
         &self,
         https: bool,
@@ -518,37 +484,30 @@ impl ConnectorService {
     async fn connect_auto(self, req: ConnectionDescriptor) -> Result<Conn, BoxError> {
         debug!("starting new connection: {:?}", req.uri());
 
-        // The sleep must be created before `self` is moved into the future below.
-        let sleep = self.config.timeout.map(|to| self.config.timer.sleep(to));
-
         // Determine if a proxy should be used for this request.
-        let fut = async {
-            let intercepted = req
-                .proxy()
-                .and_then(|prox| prox.intercept(req.uri()))
-                .or_else(|| {
-                    self.config
-                        .proxies
-                        .iter()
-                        .find_map(|prox| prox.intercept(req.uri()))
-                });
+        let intercepted = req
+            .proxy()
+            .and_then(|prox| prox.intercept(req.uri()))
+            .or_else(|| {
+                self.config
+                    .proxies
+                    .iter()
+                    .find_map(|prox| prox.intercept(req.uri()))
+            });
 
-            // If a proxy is matched, connect via proxy; otherwise, connect directly.
-            if let Some(intercepted) = intercepted {
-                self.connect_via_proxy(req, intercepted).await
-            } else {
-                self.connect_auto_proxy(req, None).await
-            }
-        };
-
-        with_deadline(fut, sleep).await
+        // If a proxy is matched, connect via proxy; otherwise, connect directly.
+        if let Some(intercepted) = intercepted {
+            self.connect_via_proxy(req, intercepted).await
+        } else {
+            self.connect_auto_proxy(req, None).await
+        }
     }
 }
 
-impl Service<ConnectionDescriptor> for ConnectorService {
+impl Service<ConnectionDescriptor> for TransportConnector {
     type Response = Conn;
     type Error = BoxError;
-    type Future = Connecting;
+    type Future = BoxFuture<'static, Result<Conn, BoxError>>;
 
     #[inline]
     fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
@@ -558,108 +517,5 @@ impl Service<ConnectionDescriptor> for ConnectorService {
     #[inline]
     fn call(&mut self, descriptor: ConnectionDescriptor) -> Self::Future {
         Box::pin(self.clone().connect_auto(descriptor))
-    }
-}
-
-/// Bounds one connect with an optional deadline, reporting expiry as [`TimedOut`].
-///
-/// The connect is polled first, so a connection ready at the deadline wins the
-/// tie, matching Tokio and Tower timeout semantics.
-async fn with_deadline<F, T>(
-    connecting: F,
-    deadline: Option<Pin<Box<dyn Sleep>>>,
-) -> Result<T, BoxError>
-where
-    F: Future<Output = Result<T, BoxError>>,
-{
-    let Some(deadline) = deadline else {
-        return connecting.await;
-    };
-
-    match futures_util::future::select(pin!(connecting), deadline).await {
-        Either::Left((result, _)) => result,
-        Either::Right(((), _)) => Err(Box::new(TimedOut) as BoxError),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::{future::pending, sync::Mutex, time::Instant};
-
-    use tower::layer::util::Identity;
-
-    use super::*;
-    use crate::{Client, ClientBuilder};
-
-    const CONNECT_TIMEOUT: Duration = Duration::from_millis(50);
-
-    /// A [`Timer`] that records every deadline it hands out.
-    #[derive(Clone)]
-    struct RecordingTimer {
-        inner: Timer,
-        sleeps: Arc<Mutex<Vec<Duration>>>,
-    }
-
-    impl wreq_proto::rt::Timer for RecordingTimer {
-        fn sleep(&self, duration: Duration) -> Pin<Box<dyn Sleep>> {
-            self.sleeps.lock().unwrap().push(duration);
-            self.inner.sleep(duration)
-        }
-
-        fn sleep_until(&self, deadline: Instant) -> Pin<Box<dyn Sleep>> {
-            self.inner.sleep_until(deadline)
-        }
-    }
-
-    /// Asserts that the connect deadline is drawn from the client's own timer.
-    ///
-    /// Nothing else here sleeps for [`CONNECT_TIMEOUT`], so seeing it in the
-    /// recording means the connector asked *this* timer for it. Reaching for
-    /// `tokio::time` instead still works under Tokio but panics on any other
-    /// runtime.
-    async fn assert_deadline_comes_from_the_timer(builder: ClientBuilder) {
-        // Accepts and then never speaks, so the TCP dial succeeds at once and
-        // only the connector's own deadline can end the TLS handshake.
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        tokio::spawn(async move {
-            let _accepted = listener.accept().await;
-            pending::<()>().await
-        });
-
-        let sleeps = Arc::new(Mutex::new(Vec::new()));
-        let client = builder
-            .timer(RecordingTimer {
-                inner: Timer::default(),
-                sleeps: Arc::clone(&sleeps),
-            })
-            .connect_timeout(CONNECT_TIMEOUT)
-            .no_proxy()
-            .build()
-            .expect("client");
-
-        let err = client
-            .get(format!("https://{addr}/"))
-            .send()
-            .await
-            .expect_err("the handshake never completes");
-
-        assert!(err.is_connect() && err.is_timeout(), "{err:?}");
-        assert!(
-            sleeps.lock().unwrap().contains(&CONNECT_TIMEOUT),
-            "connect deadline did not come from the configured timer",
-        );
-    }
-
-    #[tokio::test]
-    async fn connect_timeout_uses_the_configured_timer() {
-        assert_deadline_comes_from_the_timer(Client::builder()).await;
-    }
-
-    #[tokio::test]
-    async fn layered_connect_timeout_uses_the_configured_timer() {
-        // Any user layer switches the connector to the `WithLayers` path.
-        assert_deadline_comes_from_the_timer(Client::builder().connector_layer(Identity::new()))
-            .await;
     }
 }

--- a/src/conn/connector.rs
+++ b/src/conn/connector.rs
@@ -581,3 +581,85 @@ where
         Either::Right(((), _)) => Err(Box::new(TimedOut) as BoxError),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::{future::pending, sync::Mutex, time::Instant};
+
+    use tower::layer::util::Identity;
+
+    use super::*;
+    use crate::{Client, ClientBuilder};
+
+    const CONNECT_TIMEOUT: Duration = Duration::from_millis(50);
+
+    /// A [`Timer`] that records every deadline it hands out.
+    #[derive(Clone)]
+    struct RecordingTimer {
+        inner: Timer,
+        sleeps: Arc<Mutex<Vec<Duration>>>,
+    }
+
+    impl wreq_proto::rt::Timer for RecordingTimer {
+        fn sleep(&self, duration: Duration) -> Pin<Box<dyn Sleep>> {
+            self.sleeps.lock().unwrap().push(duration);
+            self.inner.sleep(duration)
+        }
+
+        fn sleep_until(&self, deadline: Instant) -> Pin<Box<dyn Sleep>> {
+            self.inner.sleep_until(deadline)
+        }
+    }
+
+    /// Asserts that the connect deadline is drawn from the client's own timer.
+    ///
+    /// Nothing else here sleeps for [`CONNECT_TIMEOUT`], so seeing it in the
+    /// recording means the connector asked *this* timer for it. Reaching for
+    /// `tokio::time` instead still works under Tokio but panics on any other
+    /// runtime.
+    async fn assert_deadline_comes_from_the_timer(builder: ClientBuilder) {
+        // Accepts and then never speaks, so the TCP dial succeeds at once and
+        // only the connector's own deadline can end the TLS handshake.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let _accepted = listener.accept().await;
+            pending::<()>().await
+        });
+
+        let sleeps = Arc::new(Mutex::new(Vec::new()));
+        let client = builder
+            .timer(RecordingTimer {
+                inner: Timer::default(),
+                sleeps: Arc::clone(&sleeps),
+            })
+            .connect_timeout(CONNECT_TIMEOUT)
+            .no_proxy()
+            .build()
+            .expect("client");
+
+        let err = client
+            .get(format!("https://{addr}/"))
+            .send()
+            .await
+            .expect_err("the handshake never completes");
+
+        assert!(err.is_connect() && err.is_timeout(), "{err:?}");
+        assert!(
+            sleeps.lock().unwrap().contains(&CONNECT_TIMEOUT),
+            "connect deadline did not come from the configured timer",
+        );
+    }
+
+    #[tokio::test]
+    async fn connect_timeout_uses_the_configured_timer() {
+        assert_deadline_comes_from_the_timer(Client::builder()).await;
+    }
+
+    #[tokio::test]
+    async fn layered_connect_timeout_uses_the_configured_timer() {
+        // Any user layer switches the connector to the `WithLayers` path.
+        assert_deadline_comes_from_the_timer(Client::builder().connector_layer(Identity::new()))
+            .await;
+    }
+}

--- a/src/conn/timeout.rs
+++ b/src/conn/timeout.rs
@@ -1,0 +1,166 @@
+//! Runtime-neutral timeout middleware for connector services.
+
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+};
+
+use pin_project_lite::pin_project;
+use tower::{BoxError, Layer, Service};
+use wreq_proto::rt::{Sleep, Timer as _};
+
+use crate::{error::TimedOut, rt::Timer};
+
+/// Captures timeout configuration while the connector service graph is assembled.
+///
+/// Applying this layer transfers the client timer and optional duration into [`Timeout`]; it does
+/// not start a timer until a connection attempt begins.
+#[derive(Clone)]
+pub(super) struct TimeoutLayer {
+    timer: Timer,
+    timeout: Option<Duration>,
+}
+
+/// Wraps a connector service with a deadline for each connection attempt.
+///
+/// This service remains in the client graph and creates a separate [`TimeoutFuture`] on every
+/// call, so concurrent attempts do not share timeout state.
+#[derive(Clone)]
+pub struct Timeout<S> {
+    inner: S,
+    timer: Timer,
+    timeout: Option<Duration>,
+}
+
+pin_project! {
+    /// Owns one in-flight connection and its optional timeout sleep.
+    ///
+    /// The connection is polled first; while it remains pending, the sleep can end the attempt.
+    /// Dropping this future drops both operations.
+    pub struct TimeoutFuture<F> {
+        #[pin]
+        future: F,
+        sleep: Option<Pin<Box<dyn Sleep>>>,
+    }
+}
+
+// ===== impl TimeoutLayer =====
+
+impl TimeoutLayer {
+    pub(super) fn new(timer: Timer, timeout: Option<Duration>) -> Self {
+        Self { timer, timeout }
+    }
+}
+
+impl<S> Layer<S> for TimeoutLayer {
+    type Service = Timeout<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        Timeout {
+            inner,
+            timer: self.timer.clone(),
+            timeout: self.timeout,
+        }
+    }
+}
+
+// ===== impl Timeout =====
+
+impl<S, Request> Service<Request> for Timeout<S>
+where
+    S: Service<Request>,
+    S::Error: Into<BoxError>,
+{
+    type Response = S::Response;
+    type Error = BoxError;
+    type Future = TimeoutFuture<S::Future>;
+
+    #[inline]
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx).map_err(Into::into)
+    }
+
+    fn call(&mut self, request: Request) -> Self::Future {
+        let future = self.inner.call(request);
+        let sleep = self.timeout.map(|timeout| self.timer.sleep(timeout));
+        TimeoutFuture { future, sleep }
+    }
+}
+
+// ===== impl TimeoutFuture =====
+
+impl<F, T, E> Future for TimeoutFuture<F>
+where
+    F: Future<Output = Result<T, E>>,
+    E: Into<BoxError>,
+{
+    type Output = Result<T, BoxError>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+
+        match this.future.poll(cx) {
+            Poll::Ready(result) => return Poll::Ready(result.map_err(Into::into)),
+            Poll::Pending => {}
+        }
+
+        if let Some(sleep) = this.sleep.as_mut()
+            && sleep.as_mut().poll(cx).is_ready()
+        {
+            return Poll::Ready(Err(Box::new(TimedOut)));
+        }
+
+        Poll::Pending
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{future::pending, task::Waker, time::Instant};
+
+    use super::*;
+
+    #[derive(Clone)]
+    struct ReadyTimer;
+
+    struct ReadySleep;
+
+    impl wreq_proto::rt::Timer for ReadyTimer {
+        fn sleep(&self, _duration: Duration) -> Pin<Box<dyn Sleep>> {
+            Box::pin(ReadySleep)
+        }
+
+        fn sleep_until(&self, _deadline: Instant) -> Pin<Box<dyn Sleep>> {
+            self.sleep(Duration::ZERO)
+        }
+    }
+
+    impl Future for ReadySleep {
+        type Output = ();
+
+        fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
+            Poll::Ready(())
+        }
+    }
+
+    impl Sleep for ReadySleep {
+        fn reset(self: Pin<&mut Self>, _new_deadline: Instant) {}
+    }
+
+    #[test]
+    fn connect_timeout_uses_configured_timer_without_runtime() {
+        let mut service =
+            TimeoutLayer::new(Timer::new(ReadyTimer), Some(Duration::from_millis(50)))
+                .layer(tower::service_fn(|()| pending::<Result<(), BoxError>>()));
+
+        let mut future = Box::pin(service.call(()));
+        let mut cx = Context::from_waker(Waker::noop());
+        let Poll::Ready(Err(error)) = future.as_mut().poll(&mut cx) else {
+            panic!("connect timeout did not complete");
+        };
+
+        assert!(error.is::<TimedOut>());
+    }
+}


### PR DESCRIPTION
`connect_timeout` will panic on non-Tokio runtime (compio here)

```
panicked at src/conn/connector.rs:527:
there is no reactor running, must be called from the context of a
Tokio 1.x runtime
```

This pull request passes the configured timer through `ConnectorBuilder::timer` and race the connect future against `Timer::sleep`, so it won't panic on compio

- [x] The description, docs, and comments (words meant for humans) are written by a human, not by an LLM. (https://seanmonstar.com/micro/20260729-i-want-your-own-words/)
