### PR TITLE
fix(decoder): use identity encoding for range requests

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -792,9 +792,8 @@ impl ClientBuilder {
     ///
     /// If auto gzip decompression is turned on:
     ///
-    /// - When sending a request and if the request's headers do not already contain an
-    ///   `Accept-Encoding` **and** `Range` values, the `Accept-Encoding` header is set to `gzip`.
-    ///   The request body is **not** automatically compressed.
+    /// - Requests without `Accept-Encoding` advertise `gzip`. Range requests use `Accept-Encoding:
+    ///   identity` instead. The request body is **not** automatically compressed.
     /// - When receiving a response, if its headers contain a `Content-Encoding` value of `gzip`,
     ///   both `Content-Encoding` and `Content-Length` are removed from the headers' set. The
     ///   response body is automatically decompressed.
@@ -816,9 +815,8 @@ impl ClientBuilder {
     ///
     /// If auto brotli decompression is turned on:
     ///
-    /// - When sending a request and if the request's headers do not already contain an
-    ///   `Accept-Encoding` **and** `Range` values, the `Accept-Encoding` header is set to `br`. The
-    ///   request body is **not** automatically compressed.
+    /// - Requests without `Accept-Encoding` advertise `br`. Range requests use `Accept-Encoding:
+    ///   identity` instead. The request body is **not** automatically compressed.
     /// - When receiving a response, if its headers contain a `Content-Encoding` value of `br`, both
     ///   `Content-Encoding` and `Content-Length` are removed from the headers' set. The response
     ///   body is automatically decompressed.
@@ -840,9 +838,8 @@ impl ClientBuilder {
     ///
     /// If auto zstd decompression is turned on:
     ///
-    /// - When sending a request and if the request's headers do not already contain an
-    ///   `Accept-Encoding` **and** `Range` values, the `Accept-Encoding` header is set to `zstd`.
-    ///   The request body is **not** automatically compressed.
+    /// - Requests without `Accept-Encoding` advertise `zstd`. Range requests use `Accept-Encoding:
+    ///   identity` instead. The request body is **not** automatically compressed.
     /// - When receiving a response, if its headers contain a `Content-Encoding` value of `zstd`,
     ///   both `Content-Encoding` and `Content-Length` are removed from the headers' set. The
     ///   response body is automatically decompressed.
@@ -864,9 +861,8 @@ impl ClientBuilder {
     ///
     /// If auto deflate decompression is turned on:
     ///
-    /// - When sending a request and if the request's headers do not already contain an
-    ///   `Accept-Encoding` **and** `Range` values, the `Accept-Encoding` header is set to
-    ///   `deflate`. The request body is **not** automatically compressed.
+    /// - Requests without `Accept-Encoding` advertise `deflate`. Range requests use
+    ///   `Accept-Encoding: identity` instead. The request body is **not** automatically compressed.
     /// - When receiving a response, if it's headers contain a `Content-Encoding` value that equals
     ///   to `deflate`, both values `Content-Encoding` and `Content-Length` are removed from the
     ///   headers' set. The response body is automatically decompressed.

--- a/src/client/layer/decoder.rs
+++ b/src/client/layer/decoder.rs
@@ -2,7 +2,10 @@
 
 use std::task::{Context, Poll};
 
-use http::{Request, Response};
+use http::{
+    HeaderValue, Request, Response,
+    header::{ACCEPT_ENCODING, RANGE},
+};
 use http_body::Body;
 use tower::{Layer, Service};
 use tower_http::decompression::{self, DecompressionBody, ResponseFuture};
@@ -26,15 +29,26 @@ pub(crate) struct AcceptEncoding {
     pub(crate) deflate: bool,
 }
 
-/// Layer that adds response body decompression to a service.
+/// Builds response decompression middleware for a client service.
+///
+/// `DecompressionLayer` stores the client's default [`AcceptEncoding`] configuration
+/// and applies it when constructing a [`Decompression`] service.
 #[derive(Clone)]
 pub struct DecompressionLayer {
     accept: AcceptEncoding,
 }
 
-/// Service that decompresses response bodies based on the [`AcceptEncoding`] configuration.
+/// Negotiates response encodings and transparently decodes response bodies.
+///
+/// Before forwarding a request, `Decompression` applies request-specific
+/// [`AcceptEncoding`] settings and keeps range requests on the identity representation.
+/// The wrapped `tower-http` service then advertises enabled encodings and decodes matching
+/// responses.
 #[derive(Clone)]
-pub struct Decompression<S>(Option<decompression::Decompression<S>>);
+pub struct Decompression<S> {
+    decoder: Option<decompression::Decompression<S>>,
+    enabled: bool,
+}
 
 // ===== AcceptEncoding =====
 
@@ -50,6 +64,32 @@ impl Default for AcceptEncoding {
             #[cfg(feature = "deflate")]
             deflate: true,
         }
+    }
+}
+
+impl AcceptEncoding {
+    fn is_enabled(&self) -> bool {
+        #[cfg(feature = "gzip")]
+        if self.gzip {
+            return true;
+        }
+
+        #[cfg(feature = "deflate")]
+        if self.deflate {
+            return true;
+        }
+
+        #[cfg(feature = "brotli")]
+        if self.brotli {
+            return true;
+        }
+
+        #[cfg(feature = "zstd")]
+        if self.zstd {
+            return true;
+        }
+
+        false
     }
 }
 
@@ -75,10 +115,10 @@ impl<S> Layer<S> for DecompressionLayer {
             .no_deflate()
             .no_gzip()
             .no_zstd();
-        Decompression(Some(Decompression::<S>::accept_in_place(
-            decoder,
-            &self.accept,
-        )))
+        Decompression {
+            decoder: Some(Decompression::<S>::accept_in_place(decoder, &self.accept)),
+            enabled: self.accept.is_enabled(),
+        }
     }
 }
 
@@ -127,18 +167,32 @@ where
 
     #[inline(always)]
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.0.as_mut().expect(Self::BUG_MSG).poll_ready(cx)
+        self.decoder.as_mut().expect(Self::BUG_MSG).poll_ready(cx)
     }
 
-    fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
-        if let Some(accept_encoding) = RequestConfig::<AcceptEncoding>::get(req.extensions()) {
-            if let Some(decoder) = self.0.take() {
-                self.0
-                    .replace(Decompression::accept_in_place(decoder, accept_encoding));
-            }
-            debug_assert!(self.0.is_some());
+    fn call(&mut self, mut req: Request<ReqBody>) -> Self::Future {
+        let enabled =
+            if let Some(accept_encoding) = RequestConfig::<AcceptEncoding>::get(req.extensions()) {
+                if let Some(decoder) = self.decoder.take() {
+                    self.decoder
+                        .replace(Decompression::accept_in_place(decoder, accept_encoding));
+                }
+                debug_assert!(self.decoder.is_some());
+                accept_encoding.is_enabled()
+            } else {
+                self.enabled
+            };
+
+        if enabled && req.headers().contains_key(RANGE) {
+            // tower-http does not account for Range when adding Accept-Encoding, so correct it
+            // before delegating. RFC 9110 section 14.1.2 applies byte ranges to the encoded
+            // representation, and Fetch avoids partial codings by requesting identity:
+            // https://www.rfc-editor.org/rfc/rfc9110.html#section-14.1.2
+            // https://fetch.spec.whatwg.org/#http-network-or-cache-fetch
+            req.headers_mut()
+                .insert(ACCEPT_ENCODING, HeaderValue::from_static("identity"));
         }
 
-        self.0.as_mut().expect(Self::BUG_MSG).call(req)
+        self.decoder.as_mut().expect(Self::BUG_MSG).call(req)
     }
 }

--- a/tests/gzip.rs
+++ b/tests/gzip.rs
@@ -4,6 +4,7 @@ use std::io::Write;
 use flate2::{Compression, write::GzEncoder};
 use support::server;
 use tokio::io::AsyncWriteExt;
+use wreq::header;
 
 #[tokio::test]
 async fn gzip_response() {
@@ -80,6 +81,57 @@ async fn test_accept_encoding_header_is_not_changed_if_set() {
         .unwrap();
 
     assert_eq!(res.status(), wreq::StatusCode::OK);
+}
+
+#[tokio::test]
+async fn test_range_requests_use_identity_encoding() {
+    let server = server::http(move |req| async move {
+        match req.uri().path() {
+            "/range" => {
+                assert_eq!(req.headers()[header::RANGE], "bytes=0-3");
+                assert_eq!(req.headers()[header::ACCEPT_ENCODING], "identity");
+            }
+            "/regular" => {
+                assert!(
+                    req.headers()[header::ACCEPT_ENCODING]
+                        .to_str()
+                        .unwrap()
+                        .contains("gzip")
+                );
+            }
+            "/disabled" => {
+                assert_eq!(req.headers()[header::ACCEPT_ENCODING], "gzip");
+            }
+            path => panic!("unexpected path: {path}"),
+        }
+
+        http::Response::default()
+    });
+    let base = format!("http://{}", server.addr());
+
+    let client = wreq::Client::new();
+    client
+        .get(format!("{base}/range"))
+        .header(header::RANGE, "bytes=0-3")
+        .header(header::ACCEPT_ENCODING, "gzip")
+        .send()
+        .await
+        .unwrap();
+    client.get(format!("{base}/regular")).send().await.unwrap();
+
+    wreq::Client::builder()
+        .no_gzip()
+        .no_brotli()
+        .no_zstd()
+        .no_deflate()
+        .build()
+        .unwrap()
+        .get(format!("{base}/disabled"))
+        .header(header::RANGE, "bytes=0-3")
+        .header(header::ACCEPT_ENCODING, "gzip")
+        .send()
+        .await
+        .unwrap();
 }
 
 async fn gzip_case(response_size: usize, chunk_size: usize) {


### PR DESCRIPTION
- [x] The description, docs, and comments (words meant for humans) are written by a human, not by an LLM. (https://seanmonstar.com/micro/20260729-i-want-your-own-words/)
